### PR TITLE
Ensure assets are only loaded if post type supports authors

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -512,7 +512,7 @@ function filter_rest_response_link_curies( array $additional ) : array {
 function enqueue_assets() : void {
 	/** @var WP_Post */
 	$post = get_post();
-	
+
 	if ( ! post_type_supports( $post->post_type, 'author' ) ) {
 		return;
 	}


### PR DESCRIPTION
This makes sure post types that does not support authors would not get assets enqueued, otherwise it breaks the editor.