### PR TITLE
Add supported post types filter

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -12,6 +12,7 @@ namespace Authorship\Admin;
 use WP_Post;
 
 use function Authorship\get_authors;
+use function Authorship\get_supported_post_types;
 
 const COLUMN_NAME = 'authorship';
 
@@ -27,7 +28,7 @@ function bootstrap() : void {
  * Fires as an admin screen or script is being initialized.
  */
 function init_admin_cols() : void {
-	foreach ( get_post_types_by_support( 'author' ) as $post_type ) {
+	foreach ( get_supported_post_types() as $post_type ) {
 		add_filter( "manage_{$post_type}_posts_columns", __NAMESPACE__ . '\\filter_post_columns' );
 		add_action( "manage_{$post_type}_posts_custom_column", __NAMESPACE__ . '\\action_author_column', 10, 2 );
 	}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -57,6 +57,22 @@ function bootstrap() : void {
 }
 
 /**
+ * Return list of supported post types, defaulting to those supporting 'author'
+ *
+ * @return array
+ */
+function get_supported_post_types() : array {
+	$post_types = get_post_types_by_support( 'author' );
+
+	/**
+	 * Filters the list of supported post types
+	 *
+	 * @return array $post_types List of post types that support authorship
+	 */
+	return apply_filters( 'authorship_supported_post_types', $post_types );
+}
+
+/**
  * Filters the display name of the current post's author for RSS feeds.
  *
  * @param string|null $display_name The author's display name.
@@ -363,7 +379,7 @@ function filter_wp_insert_post_data( array $data, array $postarr, array $unsanit
  * @param WP_REST_Server $server Server object.
  */
 function register_rest_api_fields( WP_REST_Server $server ) : void {
-	$post_types = get_post_types_by_support( 'author' );
+	$post_types = get_supported_post_types();
 
 	array_walk( $post_types, __NAMESPACE__ . '\\register_rest_api_field' );
 
@@ -603,7 +619,7 @@ function action_pre_get_posts( WP_Query $query ) : void {
 		$post_type = 'post';
 	}
 
-	if ( array_diff( (array) $post_type, get_post_types_by_support( 'author' ) ) ) {
+	if ( array_diff( (array) $post_type, get_supported_post_types() ) ) {
 		// If _any_ of the requested post types don't support `author`, let the default query run.
 		// @TODO I don't think anything can be done about a query for multiple post types where one or
 		// more support `author` and one or more don't.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -59,7 +59,7 @@ function bootstrap() : void {
 /**
  * Return list of supported post types, defaulting to those supporting 'author'
  *
- * @return array
+ * @return string[] List of post types to support
  */
 function get_supported_post_types() : array {
 	$post_types = get_post_types_by_support( 'author' );

--- a/inc/taxonomy.php
+++ b/inc/taxonomy.php
@@ -17,7 +17,7 @@ const TAXONOMY = 'authorship';
  * Registers the taxonomy that creates a connection between posts and users.
  */
 function init_taxonomy() : void {
-	$post_types = get_post_types_by_support( 'author' );
+	$post_types = get_supported_post_types();
 
 	register_taxonomy(
 		TAXONOMY,


### PR DESCRIPTION
This adds a filter to allow managing what post types are supported by authorship independently ( yet falling back to ) native `author` feature support.

Fixes #48 