### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ steps.composer-cache-dir.outputs.dir }}
-        key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
+        key: ${{ runner.os }}-composer-7.4-${{ hashFiles('composer.lock') }}
 
     - name: Install PHP Dependencies
       run: composer install --prefer-dist --no-progress --no-suggest --no-interaction
@@ -47,7 +47,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ steps.npm-cache-dir.outputs.dir }}
-        key: ${{ runner.os }}-${{ steps.npm-cache-dir.outputs.node-version }}-${{ steps.npm-cache-dir.outputs.npm-version }}-${{ hashFiles('**/package-lock.json') }}
+        key: ${{ runner.os }}-npm-${{ steps.npm-cache-dir.outputs.node-version }}-${{ steps.npm-cache-dir.outputs.npm-version }}-${{ hashFiles('package-lock.json') }}
 
     - name: Install JS Dependencies
       run: npm install

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -1,0 +1,44 @@
+name: JavaScript Tests
+on:
+  push:
+    branches:
+      - 'develop'
+      - 'main'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  build:
+    name: Test the Build
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v1
+
+    - name: Debugging
+      run: |
+        node -v
+        npm -v
+
+    - name: Get npm cache directory
+      id: npm-cache-dir
+      run: |
+        echo "::set-output name=dir::$(npm config get cache)"
+        echo "::set-output name=npm-version::$(npm -v)"
+        echo "::set-output name=node-version::$(node-v)"
+
+    - name: Cache Dependencies
+      id: npm-cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.npm-cache-dir.outputs.dir }}
+        key: ${{ runner.os }}-${{ steps.npm-cache-dir.outputs.node-version }}-${{ steps.npm-cache-dir.outputs.npm-version }}-${{ hashFiles('**/package-lock.json') }}
+
+    - name: Install Dependencies
+      run: npm install
+
+    - name: Run the build
+      run: |
+        npm run lint
+        npm run build

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -33,7 +33,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ steps.npm-cache-dir.outputs.dir }}
-        key: ${{ runner.os }}-${{ steps.npm-cache-dir.outputs.node-version }}-${{ steps.npm-cache-dir.outputs.npm-version }}-${{ hashFiles('**/package-lock.json') }}
+        key: ${{ runner.os }}-npm-${{ steps.npm-cache-dir.outputs.node-version }}-${{ steps.npm-cache-dir.outputs.npm-version }}-${{ hashFiles('package-lock.json') }}
 
     - name: Install Dependencies
       run: npm install

--- a/.github/workflows/php-standards.yml
+++ b/.github/workflows/php-standards.yml
@@ -39,7 +39,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ steps.composer-cache-dir.outputs.dir }}
-        key: ${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
+        key: ${{ runner.os }}-composer-7.2-${{ hashFiles('composer.lock') }}
 
     - name: Install PHP Dependencies
       run: |
@@ -49,7 +49,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: tests/cache
-        key: ${{ matrix.php }}-phpcs-${{ hashFiles('plugin.php') }}
+        key: ${{ runner.os }}-phpcs-7.2-${{ hashFiles('plugin.php') }}
 
     - name: Run the tests
       run: |

--- a/.github/workflows/php-standards.yml
+++ b/.github/workflows/php-standards.yml
@@ -1,4 +1,4 @@
-name: Unit Tests
+name: PHP Standards
 on:
   push:
     branches:
@@ -10,12 +10,7 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        php: ['7.2', '7.4']
-        wp: ['*', 'dev-nightly']
-      fail-fast: false
-    name: WP ${{ matrix.wp }} / PHP ${{ matrix.php }}
+    name: PHP Coding Standards
     runs-on: ubuntu-18.04
     steps:
     - name: Checkout repository
@@ -24,8 +19,7 @@ jobs:
     - name: Install PHP
       uses: shivammathur/setup-php@2.7.0
       with:
-        php-version: ${{ matrix.php }}
-        extensions: mysqli, xmlwriter
+        php-version: '7.2'
         coverage: none
         tools: composer:v1
 
@@ -34,7 +28,6 @@ jobs:
         php --version
         php -m
         composer --version
-        mysql --version
 
     - name: Get Composer Cache Directory
       id: composer-cache-dir
@@ -51,12 +44,17 @@ jobs:
     - name: Install PHP Dependencies
       run: |
         composer install --prefer-dist --no-progress --no-suggest --no-interaction
-        composer require --dev --prefer-dist --no-progress --no-suggest --no-interaction --update-with-dependencies roots/wordpress="${{ matrix.wp }} || *" wp-phpunit/wp-phpunit="${{ matrix.wp }} || *"
+
+    - name: PHPCS cache
+      uses: actions/cache@v2
+      with:
+        path: tests/cache
+        key: ${{ matrix.php }}-phpcs-${{ hashFiles('plugin.php') }}
 
     - name: Run the tests
       run: |
-        sudo systemctl start mysql.service
-        composer test:ut
+        composer test:phpcs
+        composer test:phpstan
       env:
         MYSQL_DATABASE: wordpress
         WP_TESTS_DB_PASS: root

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -1,0 +1,57 @@
+name: Unit Tests on Nightly
+on:
+  # Once weekly on Mondays at 06:00 UTC.
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        php: ['7.2', '7.4']
+      fail-fast: false
+    name: WP nightly / PHP ${{ matrix.php }}
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v1
+
+    - name: Install PHP
+      uses: shivammathur/setup-php@2.7.0
+      with:
+        php-version: ${{ matrix.php }}
+        extensions: mysqli, xmlwriter
+        coverage: none
+        tools: composer:v1
+
+    - name: Debugging
+      run: |
+        php --version
+        php -m
+        composer --version
+        mysql --version
+
+    - name: Get Composer Cache Directory
+      id: composer-cache-dir
+      run: |
+        echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+    - name: Cache PHP Dependencies
+      id: composer-cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.composer-cache-dir.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ matrix.php }}-${{ hashFiles('composer.lock') }}
+
+    - name: Install PHP Dependencies
+      run: |
+        composer install --prefer-dist --no-progress --no-suggest --no-interaction
+
+    - name: Run the tests
+      run: |
+        sudo systemctl start mysql.service
+        composer test:ut
+      env:
+        MYSQL_DATABASE: wordpress
+        WP_TESTS_DB_PASS: root

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -47,6 +47,7 @@ jobs:
     - name: Install PHP Dependencies
       run: |
         composer install --prefer-dist --no-progress --no-suggest --no-interaction
+        composer require --dev --update-with-dependencies --prefer-dist roots/wordpress="dev-nightly" wp-phpunit/wp-phpunit="dev-master"
 
     - name: Run the tests
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ steps.composer-cache-dir.outputs.dir }}
-        key: ${{ matrix.php }}-composer-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
+        key: ${{ runner.os }}-composer-${{ matrix.php }}-${{ hashFiles('composer.lock') }}
 
     - name: Install PHP Dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ steps.composer-cache-dir.outputs.dir }}
-        key: ${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
+        key: ${{ matrix.php }}-composer-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
 
     - name: Install PHP Dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,8 @@ jobs:
     strategy:
       matrix:
         php: ['7.2', '7.4']
-        wp: ['*', 'dev-nightly']
       fail-fast: false
-    name: WP ${{ matrix.wp }} / PHP ${{ matrix.php }}
+    name: WP 5.7 / PHP ${{ matrix.php }}
     runs-on: ubuntu-18.04
     steps:
     - name: Checkout repository
@@ -51,7 +50,6 @@ jobs:
     - name: Install PHP Dependencies
       run: |
         composer install --prefer-dist --no-progress --no-suggest --no-interaction
-        composer require --dev --prefer-dist --no-progress --no-suggest --no-interaction --update-with-dependencies roots/wordpress="${{ matrix.wp }} || *" wp-phpunit/wp-phpunit="${{ matrix.wp }} || *"
 
     - name: Run the tests
       run: |

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
     "phpcompatibility/phpcompatibility-wp": "2.1.0",
     "phpstan/phpstan": "0.12.57",
     "phpunit/phpunit": "^7",
-    "roots/wordpress": "*",
+    "roots/wordpress": "~5.7.0",
     "squizlabs/php_codesniffer": "3.5.8",
     "szepeviktor/phpstan-wordpress": "0.7.1",
     "vlucas/phpdotenv": "^3",
     "wp-cli/db-command": "^2",
-    "wp-phpunit/wp-phpunit": "*"
+    "wp-phpunit/wp-phpunit": "~5.7.0"
   },
   "config": {
     "preferred-install": "dist",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "044b8336b8820b9a53c422d006cd5b03",
+    "content-hash": "44fe9b39a1d645605cdd4e980c0ed895",
     "packages": [
         {
             "name": "composer/installers",
@@ -1908,15 +1908,15 @@
         },
         {
             "name": "roots/wordpress",
-            "version": "5.6.2",
+            "version": "5.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress.git",
-                "reference": "5.6.2"
+                "reference": "5.7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress/zipball/5.6.2"
+                "url": "https://api.github.com/repos/WordPress/WordPress/zipball/5.7"
             },
             "require": {
                 "php": ">=5.3.2",
@@ -1950,7 +1950,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2021-02-22T15:12:53+00:00"
+            "time": "2021-03-09T20:23:15+00:00"
         },
         {
             "name": "roots/wordpress-core-installer",
@@ -3405,16 +3405,16 @@
         },
         {
             "name": "wp-phpunit/wp-phpunit",
-            "version": "5.6.2",
+            "version": "5.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-phpunit/wp-phpunit.git",
-                "reference": "f6b3fb65bccc0ff70b3bc7cc241935597dbd5562"
+                "reference": "5ab77c1e1328e9bee65f60c246e33b13fc202375"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/f6b3fb65bccc0ff70b3bc7cc241935597dbd5562",
-                "reference": "f6b3fb65bccc0ff70b3bc7cc241935597dbd5562",
+                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/5ab77c1e1328e9bee65f60c246e33b13fc202375",
+                "reference": "5ab77c1e1328e9bee65f60c246e33b13fc202375",
                 "shasum": ""
             },
             "type": "library",
@@ -3444,7 +3444,7 @@
                 "test",
                 "wordpress"
             ],
-            "time": "2021-02-04T18:24:14+00:00"
+            "time": "2021-03-10T17:57:07+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
This makes a few changes that improve the CI. They're a combination of various improvements I've made in my plugins.

* Splits up the CI into multiple workflows that run in parallel, reducing the overall run time from ~3 minutes to ~1 minute
* Switches to a specific WP version in Composer for better control over version testing, also updates from 5.6 to 5.7
* Dedicated workflow for testing against WordPress nightly once a week
* Standardises the cache key names

## Before

<img width="927" alt="" src="https://user-images.githubusercontent.com/208434/112737432-dd720d80-8f5a-11eb-885d-671f66779bfd.png">

## After

<img width="929" alt="" src="https://user-images.githubusercontent.com/208434/112737431-dba84a00-8f5a-11eb-9f95-bbc91375cf02.png">
