### PR TITLE
80 filter defualt guest author

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -360,13 +360,21 @@ function filter_wp_insert_post_data( array $data, array $postarr, array $unsanit
 
 		if ( isset( $unsanitized_postarr[ POSTS_PARAM ] ) ) {
 			$authors = $unsanitized_postarr[ POSTS_PARAM ];
-		} elseif ( ! empty( $unsanitized_postarr['post_author'] ) ) {
-			$authors = [
-				$unsanitized_postarr['post_author'],
-			];
+		} else {
+			/**
+			 * Set the default authorship author. Defaults to the orignal post author.
+			 *
+			 * @param array $authors Authors to add to a post on insert if none have been passed. Default to post author.
+			 * @param WP_Post $post Post object.
+			 */
+			$authors = array_filter( apply_filters(
+				'authorship_default_author',
+				isset( $unsanitized_postarr['post_author'] ) ? [ $unsanitized_postarr['post_author'] ] : null,
+				$post
+			) );
 		}
 
-		if ( ! isset( $authors ) ) {
+		if ( empty( $authors ) ) {
 			return;
 		}
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -369,7 +369,7 @@ function filter_wp_insert_post_data( array $data, array $postarr, array $unsanit
 			 */
 			$authors = array_filter( apply_filters(
 				'authorship_default_author',
-				isset( $unsanitized_postarr['post_author'] ) ? [ $unsanitized_postarr['post_author'] ] : null,
+				[ isset( $unsanitized_postarr['post_author'] ) ? $unsanitized_postarr['post_author'] : null ],
 				$post
 			) );
 		}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -20,3 +20,6 @@ parameters:
     - inc
     - lib
     - vendor/wp-phpunit/wp-phpunit/includes
+  ignoreErrors:
+    # Uses func_get_args()
+    - '#^Function apply_filters invoked with [34567] parameters, 2 required\.$#'

--- a/tests/phpunit/test-post-saving.php
+++ b/tests/phpunit/test-post-saving.php
@@ -114,4 +114,27 @@ class TestPostSaving extends TestCase {
 
 		$this->assertSame( [ self::$users['author']->ID ], $author_ids );
 	}
+
+	public function testPostAuthorshipIsSetToEmptyWhenUpdatingPostWithNoExistingAuthorshipAndFiltered() : void {
+		$factory = self::factory()->post;
+
+		add_filter( 'authorship_default_author', '__return_empty_array' );
+
+		// Owned by Author.
+		$post = $factory->create_and_get( [
+			'post_author' => self::$users['author']->ID,
+		] );
+
+		wp_update_post( [
+			'ID'         => $post->ID,
+			'post_title' => 'Updated Title',
+		], true );
+
+		/** @var int[] */
+		$author_ids = wp_list_pluck( get_authors( $post ), 'ID' );
+
+		$this->assertEmpty( $author_ids );
+
+		remove_filter( 'authorship_default_author', '__return_empty_array' );
+	}
 }


### PR DESCRIPTION
I'm having an issue that saving a post as a draft is setting the post author to the WP User who created the post, and this trips up our editors. I'd like a way to prevent this happening. 

I found this issue: #80 that suggests adding a filter. 

How does this look?