### PR TITLE
Change PHP requirement to a minimum version

### DIFF
--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        php: ['7.4']
+        php: ['7.4', '8.0', '8.1']
       fail-fast: false
     name: WP nightly / PHP ${{ matrix.php }}
     runs-on: ubuntu-18.04

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -9,7 +9,10 @@ jobs:
   build:
     strategy:
       matrix:
-        php: ['7.4', '8.0', '8.1']
+        php: ['7.4']
+        include:
+          - php: '8.0'
+            experimental: true
       fail-fast: false
     name: WP nightly / PHP ${{ matrix.php }}
     runs-on: ubuntu-18.04
@@ -46,7 +49,7 @@ jobs:
 
     - name: Install PHP Dependencies
       run: |
-        composer install --prefer-dist --no-progress --no-suggest --no-interaction
+        composer install --prefer-dist --no-progress --no-suggest --no-interaction --ignore-platform-reqs
         composer require --dev --update-with-dependencies --prefer-dist roots/wordpress="dev-nightly" wp-phpunit/wp-phpunit="dev-master"
 
     - name: Run the tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,10 @@ jobs:
   build:
     strategy:
       matrix:
-        php: ['7.4', '8.0', '8.1']
+        php: ['7.4']
+        include:
+          - php: '8.0'
+            experimental: true
       fail-fast: false
     name: WP 5.9 / PHP ${{ matrix.php }}
     runs-on: ubuntu-18.04
@@ -49,7 +52,7 @@ jobs:
 
     - name: Install PHP Dependencies
       run: |
-        composer install --prefer-dist --no-progress --no-suggest --no-interaction
+        composer install --prefer-dist --no-progress --no-suggest --no-interaction --ignore-platform-reqs
 
     - name: Run the tests
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        php: ['7.4']
+        php: ['7.4', '8.0', '8.1']
       fail-fast: false
     name: WP 5.9 / PHP ${{ matrix.php }}
     runs-on: ubuntu-18.04

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "description": "Authorship",
   "license": "GPL-3.0-or-later",
   "require": {
-    "php": "~7.2",
+    "php": ">=7.2",
     "composer/installers": "~1.0",
     "humanmade/asset-loader": "^0.5.0"
   },


### PR DESCRIPTION
Currently Authorship is uninstallable using composer and PHP 8.0 or higher.

I ran the PHPCS compatibility check and there are no warnings or errors for both 8.0 and 8.1.

I think this could be a patch release, as it falls more under bug territory and there are no other changes.