### PR TITLE
Build/release: Use --legacy-peer-deps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
         key: ${{ runner.os }}-npm-${{ steps.npm-cache-dir.outputs.node-version }}-${{ steps.npm-cache-dir.outputs.npm-version }}-${{ hashFiles('package-lock.json') }}
 
     - name: Install JS Dependencies
-      run: npm install
+      run: npm install --legacy-peer-deps
 
     - name: Build Assets
       run: npm run build


### PR DESCRIPTION
With newer versions of npm peer dependencies are resolved and installed automatically. Unfortunately in our case it doesn't seem like we can easily resolve the conflicts with peer dependencies without changing things upstream. Current conflicts around the following dev dependencies:

* eslint-plugin-jsdoc
* eslint-config-react-app
* babel-eslint
* @humanmade/eslint-config

The conflicts originate from the versions defined in [humanmade/eslint-config](https://github.com/humanmade/coding-standards/blob/master/packages/eslint-config-humanmade/package.json). This PR avoids installing or attempting to resolve peer dependencies using `--legacy-peer-deps`.

Done earlier for the js tests here: https://github.com/humanmade/authorship/pull/102#issuecomment-1156071970