### PR TITLE
Show all users in post author column.

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -428,6 +428,7 @@ function validate_authors( $authors, WP_REST_Request $request, string $param, st
 
 	/** @var WP_User[] */
 	$users = get_users( [
+		'blog_id' => 0, // Check all sites.
 		'include' => $authors,
 		'orderby' => 'include',
 	] );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -428,7 +428,8 @@ function validate_authors( $authors, WP_REST_Request $request, string $param, st
 
 	/** @var WP_User[] */
 	$users = get_users( [
-		'blog_id' => 0, // Check all sites.
+		// Check all sites.
+		'blog_id' => 0,
 		'include' => $authors,
 		'orderby' => 'include',
 	] );

--- a/inc/template.php
+++ b/inc/template.php
@@ -21,18 +21,16 @@ use WP_User;
  * @return int[] Array of user IDs.
  */
 function get_author_ids( WP_Post $post ) : array {
-	$authors = wp_get_post_terms( $post->ID, TAXONOMY );
-	// If $authors is an error or empty.
-	if ( is_wp_error( $authors ) || empty( $authors ) ) {
-		// Check if the post_type supports Authorship.
-		if ( is_post_type_supported( $post->post_type ) ) {
-			// Check the post_type support author.
-			if ( post_type_supports( $post->post_type, 'author' ) ) {
-				return [ intval( $post->post_author ) ];
-			}
-			return [];
+	if ( ! is_post_type_supported( $post->post_type ) ) {
+		if ( post_type_supports( $post->post_type, 'author' ) ) {
+			return [ intval( $post->post_author ) ];
 		}
 
+		return [];
+	}
+
+	$authors = wp_get_post_terms( $post->ID, TAXONOMY );
+	if ( is_wp_error( $authors ) ) {
 		return [];
 	}
 
@@ -55,7 +53,7 @@ function get_authors( WP_Post $post ) : array {
 
 	/** @var WP_User[] */
 	$users = get_users( [
-		'blog_id' => 0,
+		'blog_id' => 0, // Check all sites.
 		'include' => $author_ids,
 		'orderby' => 'include',
 	] );
@@ -158,6 +156,7 @@ function set_authors( WP_Post $post, array $authors ) : array {
 
 	/** @var WP_User[] */
 	$users = get_users( [
+		'blog_id' => 0, // Check all sites.
 		'include' => $authors,
 		'orderby' => 'include',
 	] );

--- a/inc/template.php
+++ b/inc/template.php
@@ -157,7 +157,7 @@ function set_authors( WP_Post $post, array $authors ) : array {
 
 	/** @var WP_User[] */
 	$users = get_users( [
-		 // Check all sites.
+		// Check all sites.
 		'blog_id' => 0,
 		'include' => $authors,
 		'orderby' => 'include',

--- a/inc/template.php
+++ b/inc/template.php
@@ -53,7 +53,8 @@ function get_authors( WP_Post $post ) : array {
 
 	/** @var WP_User[] */
 	$users = get_users( [
-		'blog_id' => 0, // Check all sites.
+		// Check all sites.
+		'blog_id' => 0,
 		'include' => $author_ids,
 		'orderby' => 'include',
 	] );
@@ -156,7 +157,8 @@ function set_authors( WP_Post $post, array $authors ) : array {
 
 	/** @var WP_User[] */
 	$users = get_users( [
-		'blog_id' => 0, // Check all sites.
+		 // Check all sites.
+		'blog_id' => 0,
 		'include' => $authors,
 		'orderby' => 'include',
 	] );

--- a/inc/template.php
+++ b/inc/template.php
@@ -21,16 +21,18 @@ use WP_User;
  * @return int[] Array of user IDs.
  */
 function get_author_ids( WP_Post $post ) : array {
-	if ( ! is_post_type_supported( $post->post_type ) ) {
-		if ( post_type_supports( $post->post_type, 'author' ) ) {
-			return [ intval( $post->post_author ) ];
+	$authors = wp_get_post_terms( $post->ID, TAXONOMY );
+	// If $authors is an error or empty.
+	if ( is_wp_error( $authors ) || empty( $authors ) ) {
+		// Check if the post_type supports Authorship.
+		if ( is_post_type_supported( $post->post_type ) ) {
+			// Check the post_type support author.
+			if ( post_type_supports( $post->post_type, 'author' ) ) {
+				return [ intval( $post->post_author ) ];
+			}
+			return [];
 		}
 
-		return [];
-	}
-
-	$authors = wp_get_post_terms( $post->ID, TAXONOMY );
-	if ( is_wp_error( $authors ) ) {
 		return [];
 	}
 
@@ -53,6 +55,7 @@ function get_authors( WP_Post $post ) : array {
 
 	/** @var WP_User[] */
 	$users = get_users( [
+		'blog_id' => 0,
 		'include' => $author_ids,
 		'orderby' => 'include',
 	] );

--- a/tests/phpunit/test-multisite.php
+++ b/tests/phpunit/test-multisite.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Multisite tests for the plugin.
+ *
+ * @package authorship
+ */
+
+declare( strict_types=1 );
+
+namespace Authorship\Tests;
+
+use const Authorship\POSTS_PARAM;
+
+/**
+ * @group ms-required
+ */
+class TestMultisite extends TestCase {
+	/**
+	 * Super admin.
+	 *
+	 * @var \WP_User
+	 */
+	protected static $super_admin;
+
+	/**
+	 * Sub site.
+	 *
+	 * @var \WP_Site
+	 */
+	protected static $sub_site;
+
+	/**
+	 * Set up class test fixtures.
+	 *
+	 * @param \WP_UnitTest_Factory $factory Test factory.
+	 */
+	public static function wpSetUpBeforeClass( \WP_UnitTest_Factory $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
+
+		// Create a super admin user.
+		self::$super_admin = $factory->user->create_and_get( [
+			'role' => 'administrator',
+			'display_name' => 'Super Admin',
+			'user_email' => "super-admin.role@example.org",
+		] );
+
+		grant_super_admin( self::$super_admin->ID );
+
+		// Create a subsite.
+		self::$sub_site = $factory->blog->create_and_get( [
+			'domain' => 'example.org',
+			'path' => '/subsite',
+			'title' => 'Authorship Sub Site',
+			'user_id' => self::$users['admin']->ID,
+		] );
+	}
+
+	public function testSuperAdminWithNoRoleOnSite() {
+		// Change site.
+		switch_to_blog( self::$sub_site->blog_id );
+
+		// Confirm no role on current site.
+		$super_admin = get_user_by( 'ID', self::$super_admin->ID );
+		$this->assertEmpty( $super_admin->roles );
+
+		$factory = self::factory()->post;
+
+		// Attributed to Super Admin, owned by Admin.
+		$post = $factory->create_and_get( [
+			'post_author' => self::$users['admin']->ID,
+			POSTS_PARAM   => [
+				self::$super_admin->ID,
+			],
+		] );
+
+		// Check super admin ID is stored.
+		$author_ids = \Authorship\get_author_ids( $post );
+		$this->assertSame( [ self::$super_admin->ID ], $author_ids );
+
+		$author_url = get_author_posts_url( self::$super_admin->ID );
+		$this->assertTrue( strpos( $author_url, '/subsite/' ) !== false );
+		$this->go_to( $author_url );
+
+		/** @var \WP_Query */
+		global $wp_query, $authordata;
+
+		$this->assertQueryTrue( 'is_author', 'is_archive' );
+		$this->assertTrue( is_author( self::$super_admin->ID ) );
+		$this->assertSame( [ $post->ID ], wp_list_pluck( $wp_query->posts, 'ID' ) );
+		$this->assertSame( self::$super_admin->ID, $authordata->ID );
+
+		restore_current_blog();
+	}
+
+}

--- a/tests/phpunit/test-multisite.php
+++ b/tests/phpunit/test-multisite.php
@@ -41,7 +41,7 @@ class TestMultisite extends TestCase {
 		self::$super_admin = $factory->user->create_and_get( [
 			'role' => 'administrator',
 			'display_name' => 'Super Admin',
-			'user_email' => "super-admin.role@example.org",
+			'user_email' => 'super-admin.role@example.org',
 		] );
 
 		grant_super_admin( self::$super_admin->ID );


### PR DESCRIPTION
Related issue : https://github.com/humanmade/product-dev/issues/993

#### Issue
When viewing the posts screen you don't see all the authors of a given post.

#### Solution
The function ` get_author_ids` wasn't returning the author ID's of all posts. This PR now shows all users in the column even when the user hasn't been assigned a role.

#### Steps to test

1. Ensure you have a post where the post author is a super admin that hasn't been added to the site.
2. Viewing all posts this will be identifiable by a post which has no author listed. It will be blank.
![Screenshot 2022-08-16 at 10 11 51](https://user-images.githubusercontent.com/16571365/184830854-10230984-2743-495a-a460-d71a10a3425a.png)
3. Applying the PR allows the site to reference a user despite them having no assigned role on the site, **Altis Dev** is a super admin and isn't assigned to the current site with any role/s :
![Screenshot 2022-08-16 at 10 12 22](https://user-images.githubusercontent.com/16571365/184831092-b247870a-dd9e-423a-a05f-aa8acbbf1474.png)

