### PR TITLE
Fixes the phpstan config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   wordpress:
     name: Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: Test the Build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1

--- a/.github/workflows/php-standards.yml
+++ b/.github/workflows/php-standards.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: PHP Coding Standards
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -15,7 +15,7 @@ jobs:
             experimental: true
       fail-fast: false
     name: WP nightly / PHP ${{ matrix.php }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
             experimental: true
       fail-fast: false
     name: WP 5.9 / PHP ${{ matrix.php }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -22,7 +22,7 @@ parameters:
     - inc
     - lib
     - vendor/wp-phpunit/wp-phpunit/includes
+    - vendor/wp-cli/wp-cli
   ignoreErrors:
     # Uses func_get_args()
     - '#^Function apply_filters invoked with [34567] parameters, 2 required\.$#'
-    - vendor/wp-cli/wp-cli


### PR DESCRIPTION
While resolving a merge conflict for https://github.com/humanmade/authorship/pull/91 I made a change that looked ok, but phpstan balked at it. This resolves it, and PHPStan runs ok now.

Also bumped github actions from ubuntu 18 to 20 to avoid planned brownouts to make us upgrade