### PR TITLE
CLI command to migrate legacy WP users

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,20 @@ If this flag is *not* set:
 * When creating a new post, if the `--post_author` flag is set then it will be used for attributed authors
 * When updating an existing post, no change will be made to attributed authors
 
+### Migration of WordPress authors on existing posts.
+
+If you activate Authorship on an existing site, all content already created will not have authorship data set for old content. This breaks things such as author archive pages.
+
+This command will set the WordPress author as the authorship user for any posts with no authorship user. (Optionally you can override any existing authorship data, updating it with the WordPress post author).
+
+```sh
+wp authorship migrate wp-authors --dry-run=true
+```
+
+The command will perform a dry run by default, setting `--dry-run=false` will make changes to the database.
+
+This command will not overwrite or update Authorship data unless the `--overwrite-authors=true` flag is set.
+
 ### PublishPress Authors Migration
 
 Authorship provides a command for creating Authorship data using data from PublishPress Authors. This allows a non-destructive migration path from PublishPress Authors.

--- a/inc/cli/class-migrate-command.php
+++ b/inc/cli/class-migrate-command.php
@@ -72,7 +72,6 @@ class Migrate_Command extends WP_CLI_Command {
 			WP_CLI::warning( 'Dry run is disabled, data will be modified.' );
 		}
 
-
 		// If --overwrite-authors is not set, then it will default to false.
 		$overwrite = filter_var( $assoc_args['overwrite-authors'] ?? false, FILTER_VALIDATE_BOOLEAN );
 
@@ -117,8 +116,8 @@ class Migrate_Command extends WP_CLI_Command {
 				// Set post author as Authorship author.
 				\Authorship\set_authors( $post, [ $post->post_author ] );
 
-			$count++;
-			} //end foreach
+				$count++;
+			}//end foreach
 
 			// Avoid memory exhaustion issues.
 			$this->reset_local_object_cache();

--- a/inc/cli/class-migrate-command.php
+++ b/inc/cli/class-migrate-command.php
@@ -127,7 +127,7 @@ class Migrate_Command extends WP_CLI_Command {
 			sleep( 2 );
 
 			$paged++;
-		} //end foreach
+		}//end foreach
 		while ( count( $posts ) );
 
 		if ( true === $dry_run ) {

--- a/inc/cli/class-migrate-command.php
+++ b/inc/cli/class-migrate-command.php
@@ -114,7 +114,7 @@ class Migrate_Command extends WP_CLI_Command {
 				}
 
 				// Set post author as Authorship author.
-				\Authorship\set_authors( $post, [ $post->post_author ] );
+				\Authorship\set_authors( $post, [ intval( $post->post_author ) ] );
 
 				$count++;
 			}//end foreach

--- a/inc/cli/class-migrate-command.php
+++ b/inc/cli/class-migrate-command.php
@@ -127,8 +127,7 @@ class Migrate_Command extends WP_CLI_Command {
 			sleep( 2 );
 
 			$paged++;
-		}//end foreach
-		while ( count( $posts ) );
+		} while ( count( $posts ) );
 
 		if ( true === $dry_run ) {
 			WP_CLI::success( sprintf( '%d posts would have had Authorship data added if this was not a dry run.', $count ) );

--- a/inc/cli/class-migrate-command.php
+++ b/inc/cli/class-migrate-command.php
@@ -115,7 +115,7 @@ class Migrate_Command extends WP_CLI_Command {
 
 				// Set post author as Authorship author.
 				if ( ! $dry_run ) {
-					\Authorship\set_authors( $post, [ intval( $post->post_author ] );
+					\Authorship\set_authors( $post, [ intval( $post->post_author ) ] );
 				}
 
 				$count++;

--- a/inc/cli/class-migrate-command.php
+++ b/inc/cli/class-migrate-command.php
@@ -114,7 +114,9 @@ class Migrate_Command extends WP_CLI_Command {
 				}
 
 				// Set post author as Authorship author.
-				\Authorship\set_authors( $post, [ intval( $post->post_author ) ] );
+				if ( ! $dry_run ) {
+					\Authorship\set_authors( $post, [ intval( $post->post_author ] );
+				}
 
 				$count++;
 			}//end foreach


### PR DESCRIPTION
If you enable Authorship on an existing site, author archives break because authorship authors are not set. 

This adds a CLI command to run through all posts that have no authorship author set, and sets adds the post_author to authorship.

Optionally, you can pass `--override-authorship` to remove all authorship users and replace with WordPress authors.

Fixes #78.