### PR TITLE
Docs: Add note to contributing RE  whitespace in plugin headers of readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,8 +71,9 @@ These are the steps to take to release a new version of Authorship (for contribu
 1. If this is a non-patch release, check issues and PRs assigned to the patch or minor milestones that will get skipped. Reassign as necessary.
 1. Ensure you're on the `develop` branch and all the changes for this release have been merged in.
 1. Ensure `README.md` contains an up to date description, "Tested up to" version, FAQs, screenshots, etc.
-1. Run `composer test` and ensure everything passes.
-1. Prepare a changelog for [the Releases page on GitHub](https://github.com/humanmade/authorship/releases).
+    * **Note:** The double spaces at the end of the lines in the plugin header section at the top of README.md must be kept, to ensure line breaks are created.
+3. Run `composer test` and ensure everything passes.
+4. Prepare a changelog for [the Releases page on GitHub](https://github.com/humanmade/authorship/releases).
    - The `git changelog -x` command from [Git Extras](https://github.com/tj/git-extras) is handy for this.
 
 ### For Release


### PR DESCRIPTION
Update CONTRIBUTING.md to add a note reminding that that whitespace at the end of the lines in the plugin header of README.md must be kept to ensure line breaks. 