### PR TITLE
Fix REST response callback

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -309,6 +309,10 @@ function filter_rest_request_after_callbacks( $result, array $handler, WP_REST_R
 
 	$data = $result->get_data();
 
+	if ( ! is_array( $data ) ) {
+		return $result;
+	}
+
 	if ( ! isset( $data[ REST_PARAM ] ) ) {
 		return $result;
 	}


### PR DESCRIPTION
Check that `$data` is an array before checking if `REST_PARAM` is set. 
Avoid triggering `Cannot use object of type stdClass as array` when response data is an object.