### PR TITLE
Remove unused vars

### DIFF
--- a/src/components/AuthorsSelect.tsx
+++ b/src/components/AuthorsSelect.tsx
@@ -107,7 +107,7 @@ const AuthorsSelect = ( props: AuthorsSelectProps ): ReactElement => {
 	 * Declares styles for elements that can't easily be targeted with a CSS selector.
 	 */
 	const styles: Styles<Option, true> = {
-		input: ( provided, state ) => ( {
+		input: () => ( {
 			margin: 0,
 			width: '100%',
 		} ),


### PR DESCRIPTION
The JS linting has started breaking because of these unused vars. 

[I suspect it started being flagged after this update to the ESLint rules.](https://github.com/humanmade/authorship/commit/b0d4a7ed955c3133e1277a0b26445d43c619ea94) although I don't understand why checks weren't failing then 🤔 