### PR TITLE
Set node version for build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
+    - name: Setup Node
+      uses: actions/setup-node@v3
+      with:
+        node-version-file: '.nvmrc'
+
     - name: Install PHP
       uses: shivammathur/setup-php@2.7.0
       with:


### PR DESCRIPTION
Hotfix. In #129 I added a setup step to the JS Test action to set the node version. This is required in order to build assets, as it fails on v18. 

However upon attempting to deploy the latest release, I discovered that I needed to add this step to the `build.yml` file too. 