### PR TITLE
Prevent errors when wp_insert_post filters send an unexpected type

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -340,6 +340,12 @@ function filter_rest_request_after_callbacks( $result, array $handler, WP_REST_R
  * @return mixed[] An array of slashed, sanitized, and processed post data.
  */
 function filter_wp_insert_post_data( array $data, array $postarr, array $unsanitized_postarr ) : array {
+
+	// Make sure the unsanitized post array is actually an array. Core sometimes passes it as a WP_Post object.
+	if ( ! is_array( $unsanitized_postarr ) ) {
+		$unsanitized_postarr = (array) $unsanitized_postarr;
+	}
+
 	/**
 	 * Fires once a post has been saved.
 	 *


### PR DESCRIPTION
The third argument passed along with the `wp_insert_post_data` hook can be a number of different types. 

This avoid PHP errors trying to access a WP_Post object as an array by coercing that value to an array before trying to access it.