### PR TITLE
Fix get author term field

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -35,7 +35,7 @@ function get_author_ids( WP_Post $post ) : array {
 	}
 
 	return array_map( function ( WP_Term $term ) : int {
-		return intval( $term->name );
+		return intval( $term->slug );
 	}, $authors );
 }
 


### PR DESCRIPTION
The field used to map user ID is the slug (used elsewhere to make relevant tax queries)