### PR TITLE
Feat add author name

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -35,7 +35,7 @@ function get_author_ids( WP_Post $post ) : array {
 	}
 
 	return array_map( function ( WP_Term $term ) : int {
-		return intval( $term->name );
+		return intval( $term->slug );
 	}, $authors );
 }
 

--- a/tests/phpunit/test-post-saving.php
+++ b/tests/phpunit/test-post-saving.php
@@ -115,6 +115,21 @@ class TestPostSaving extends TestCase {
 		$this->assertSame( [ self::$users['author']->ID ], $author_ids );
 	}
 
+	public function testPostAuthorshipTermNameIsSetToAuthorDisplaynameWhenCreatingPost() : void {
+		/** @var int */
+		$post_id = wp_insert_post( [
+			'post_title'  => 'Testing',
+			'post_author' => self::$users['author']->ID,
+		], true );
+		/** @var \WP_Post */
+		$post = get_post( $post_id );
+
+		/** @var \WP_Term[] */
+		$author_terms = wp_get_post_terms( $post->ID, TAXONOMY );
+
+		$this->assertEquals( self::$users['author']->display_name, $author_terms[0]->name );
+	}
+
 	public function testPostAuthorshipIsSetToEmptyWhenUpdatingPostWithNoExistingAuthorshipAndFiltered() : void {
 		$factory = self::factory()->post;
 

--- a/tests/phpunit/test-user-display-name.php
+++ b/tests/phpunit/test-user-display-name.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * General user saving tests.
+ *
+ * @package authorship
+ */
+
+declare( strict_types=1 );
+
+namespace Authorship\Tests;
+
+use const Authorship\TAXONOMY;
+
+class TestUserDisplayName extends TestCase {
+	public function testPostAuthorshipUpdatesTermNameWhenUserDisplayNameIsUpdated() : void {
+		// Create an author term for the author user.
+		$author_term = get_term_by( 'slug', (string) self::$users['author']->ID, TAXONOMY );
+		if ( ! $author_term ) {
+			wp_insert_term( self::$users['author']->ID, TAXONOMY );
+			$author_term = get_term_by( 'slug', (string) self::$users['author']->ID, TAXONOMY );
+		}
+
+		$display_name = 'New Author Name';
+
+		wp_update_user( [
+			'ID' => self::$users['author']->ID,
+			'display_name' => $display_name,
+		] );
+
+		$author_term = get_term_by( 'slug', (string) self::$users['author']->ID, TAXONOMY );
+
+		$this->assertSame( $display_name, $author_term->name );
+	}
+}


### PR DESCRIPTION
Except in #139 (which is probably a typo/mistake), Authorship doesn't make use of `$term->name` in `authorship` taxonomy. This might be a good idea to store the user display name as term name and keep them in sync.

This will intriduce some nice benefits almost without any tradefoffs (at least I couldn't see a case where names could be out of sync).

I'm first trying to push this to solve a problem I'm facing with Relevanssi but could apply to any indexing technology. Since Authorship only stores IDs in terms (in both `name` AND `slug`), It's quite hard to make it index the author (display) name. With `$term->name` storing author display name, just mark the `authorship` taxonomy as "to be indexed" and you're done. Searches containing author display names will now show up in your post search results, just [like it does with Co-Authors-Plus](https://www.relevanssi.com/knowledge-base/relevanssi-and-co-authors-plus/).

It would also bring more performance to `get_author_names` avoiding the cost of querying user objects.

Side note: it would be nice to bump your dev dependencies and drop fixed constraints, it does not play well recent PHP versions (8/8.1). PHPStan for example evolved a lot since `0.12.57` and will raise more potential problems :)