### PR TITLE
Support `has_published_posts` arg in `WP_User_Query`

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -708,8 +708,8 @@ function action_reference_pre_user_query( WP_User_Query $query ) : void {
 		$post_types
 	);
 	$unsupported_post_types = array_diff(
-		$supported_post_types,
-		$post_types
+		$post_types,
+		$supported_post_types
 	);
 
 	foreach ( $post_types as &$post_type ) {

--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -27,6 +27,13 @@ tests_add_filter( 'muplugins_loaded', function() use ( $_plugin_dir ) : void {
 	require_once $_plugin_dir . '/plugin.php';
 } );
 
+tests_add_filter( 'init', function() : void {
+	register_post_type( 'test_cpt_no_author', [
+		'public' => true,
+		'supports' => [ 'title', 'editor' ],
+	] );
+} );
+
 require_once $_tests_dir . '/includes/bootstrap.php';
 require_once __DIR__ . '/testcase.php';
 require_once __DIR__ . '/email-testcase.php';

--- a/tests/phpunit/test-wp-user-query.php
+++ b/tests/phpunit/test-wp-user-query.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * WP_Query tests.
+ *
+ * @package authorship
+ */
+
+declare( strict_types=1 );
+
+namespace Authorship\Tests;
+
+use const Authorship\GUEST_ROLE;
+use const Authorship\POSTS_PARAM;
+
+use WP_User_Query;
+
+class TestWPUserQuery extends TestCase {
+	public function testQueryForAuthorWithPublishedPostsReturnsAttributedAuthors() : void {
+		$factory = self::factory()->post;
+
+		// Attributed to Editor, owned by Admin.
+		$factory->create_and_get( [
+			'post_author' => self::$users['admin']->ID,
+			'post_status' => 'publish',
+			POSTS_PARAM   => [
+				self::$users['editor']->ID,
+			],
+		] );
+
+		// Attributed to Editor, owned by nobody.
+		$factory->create_and_get( [
+			'post_status' => 'publish',
+			POSTS_PARAM   => [
+				self::$users['editor']->ID,
+			],
+		] );
+
+		// Attributed to Guest, owned by Author.
+		$factory->create_and_get( [
+			'post_author' => self::$users['author']->ID,
+			'post_status' => 'publish',
+			POSTS_PARAM   => [
+				self::$users[ GUEST_ROLE ]->ID,
+			],
+		] );
+
+		// Attributed to Guest, owned by Admin.
+		$factory->create_and_get( [
+			'post_author' => self::$users['admin']->ID,
+			'post_status' => 'publish',
+			POSTS_PARAM   => [
+				self::$users[ GUEST_ROLE ]->ID,
+			],
+		] );
+
+		// Owned by Author.
+		$factory->create_and_get( [
+			'post_author' => self::$users['author']->ID,
+			'post_status' => 'publish',
+			'post_type'   => 'non_existent_type',
+		] );
+
+		// Owned by Admin.
+		$factory->create_and_get( [
+			'post_author' => self::$users['admin']->ID,
+			'post_status' => 'publish',
+			'post_type'   => 'non_existent_type',
+		] );
+
+		$common_args = [
+			'fields'  => 'ids',
+			'orderby' => 'ID',
+			'order'   => 'ASC',
+		];
+
+		// Queries for attributed published post types.
+		$test_args = [
+			'has_published_posts' => [ 'post' ],
+		];
+
+		foreach ( $test_args as $test_key => $test_value ) {
+			$args = array_merge( $common_args, [
+				$test_key => $test_value,
+			] );
+
+			$query = new WP_User_Query();
+			$users = $query->query( $args );
+
+			$this->assertSame(
+				[ self::$users['editor']->ID, self::$users[ GUEST_ROLE ]->ID ],
+				$users,
+				"User IDs for attributed {$test_key} query are incorrect."
+			);
+		}
+
+		// Queries for non attributed published post types.
+		$test_args = [
+			'has_published_posts' => [ 'non_existent_type' ],
+		];
+
+		foreach ( $test_args as $test_key => $test_value ) {
+			$args = array_merge( $common_args, [
+				$test_key => $test_value,
+			] );
+
+			$query = new WP_User_Query();
+			$users = $query->query( $args );
+
+			$this->assertSame(
+				[ self::$users['admin']->ID, self::$users['author']->ID ],
+				$users,
+				"User IDs for non attributed {$test_key} query are incorrect."
+			);
+		}
+
+		// Queries for non attributed published post types.
+		$test_args = [
+			'has_published_posts' => [ 'post', 'non_existent_type' ],
+		];
+
+		foreach ( $test_args as $test_key => $test_value ) {
+			$args = array_merge( $common_args, [
+				$test_key => $test_value,
+			] );
+
+			$query = new WP_User_Query();
+			$users = $query->query( $args );
+
+			$this->assertSame(
+				[
+					self::$users['admin']->ID,
+					self::$users['editor']->ID,
+					self::$users['author']->ID,
+					self::$users[ GUEST_ROLE ]->ID
+				],
+				$users,
+				"User IDs for combined attributed and non-attributed {$test_key} query are incorrect."
+			);
+		}
+	}
+
+}

--- a/tests/phpunit/test-wp-user-query.php
+++ b/tests/phpunit/test-wp-user-query.php
@@ -57,14 +57,14 @@ class TestWPUserQuery extends TestCase {
 		$factory->create_and_get( [
 			'post_author' => self::$users['author']->ID,
 			'post_status' => 'publish',
-			'post_type'   => 'non_existent_type',
+			'post_type'   => 'test_cpt_no_author',
 		] );
 
 		// Owned by Admin.
 		$factory->create_and_get( [
 			'post_author' => self::$users['admin']->ID,
 			'post_status' => 'publish',
-			'post_type'   => 'non_existent_type',
+			'post_type'   => 'test_cpt_no_author',
 		] );
 
 		$common_args = [
@@ -96,7 +96,7 @@ class TestWPUserQuery extends TestCase {
 
 		// Queries for non attributed published post types.
 		$test_args = [
-			'has_published_posts' => [ 'non_existent_type' ],
+			'has_published_posts' => [ 'test_cpt_no_author' ],
 		];
 
 		foreach ( $test_args as $test_key => $test_value ) {
@@ -117,7 +117,7 @@ class TestWPUserQuery extends TestCase {
 
 		// Queries for non attributed published post types.
 		$test_args = [
-			'has_published_posts' => [ 'post', 'non_existent_type' ],
+			'has_published_posts' => [ 'post', 'test_cpt_no_author' ],
 		];
 
 		foreach ( $test_args as $test_key => $test_value ) {

--- a/tests/phpunit/test-wp-user-query.php
+++ b/tests/phpunit/test-wp-user-query.php
@@ -83,7 +83,9 @@ class TestWPUserQuery extends TestCase {
 				$test_key => $test_value,
 			] );
 
-			$users = new WP_User_Query( $args );
+			$query = new WP_User_Query( $args );
+			$users = (array) $query->get_results();
+			$users = array_map( 'absint', $users );
 
 			$this->assertSame(
 				[ self::$users['editor']->ID, self::$users[ GUEST_ROLE ]->ID ],
@@ -102,7 +104,9 @@ class TestWPUserQuery extends TestCase {
 				$test_key => $test_value,
 			] );
 
-			$users = new WP_User_Query( $args );
+			$query = new WP_User_Query( $args );
+			$users = (array) $query->get_results();
+			$users = array_map( 'absint', $users );
 
 			$this->assertSame(
 				[ self::$users['admin']->ID, self::$users['author']->ID ],
@@ -121,14 +125,16 @@ class TestWPUserQuery extends TestCase {
 				$test_key => $test_value,
 			] );
 
-			$users = new WP_User_Query( $args );
+			$query = new WP_User_Query( $args );
+			$users = (array) $query->get_results();
+			$users = array_map( 'absint', $users );
 
 			$this->assertSame(
 				[
 					self::$users['admin']->ID,
 					self::$users['editor']->ID,
 					self::$users['author']->ID,
-					self::$users[ GUEST_ROLE ]->ID
+					self::$users[ GUEST_ROLE ]->ID,
 				],
 				$users,
 				"User IDs for combined attributed and non-attributed {$test_key} query are incorrect."

--- a/tests/phpunit/test-wp-user-query.php
+++ b/tests/phpunit/test-wp-user-query.php
@@ -68,7 +68,7 @@ class TestWPUserQuery extends TestCase {
 		] );
 
 		$common_args = [
-			'fields'  => 'ids',
+			'fields'  => 'ID',
 			'orderby' => 'ID',
 			'order'   => 'ASC',
 		];
@@ -83,8 +83,7 @@ class TestWPUserQuery extends TestCase {
 				$test_key => $test_value,
 			] );
 
-			$query = new WP_User_Query();
-			$users = $query->query( $args );
+			$users = new WP_User_Query( $args );
 
 			$this->assertSame(
 				[ self::$users['editor']->ID, self::$users[ GUEST_ROLE ]->ID ],
@@ -103,8 +102,7 @@ class TestWPUserQuery extends TestCase {
 				$test_key => $test_value,
 			] );
 
-			$query = new WP_User_Query();
-			$users = $query->query( $args );
+			$users = new WP_User_Query( $args );
 
 			$this->assertSame(
 				[ self::$users['admin']->ID, self::$users['author']->ID ],
@@ -123,8 +121,7 @@ class TestWPUserQuery extends TestCase {
 				$test_key => $test_value,
 			] );
 
-			$query = new WP_User_Query();
-			$users = $query->query( $args );
+			$users = new WP_User_Query( $args );
 
 			$this->assertSame(
 				[


### PR DESCRIPTION
Fixes #145

Maybe not ideal, but similar to the mechanism for finding distinct post_author values in core. Results should be cached I believe.