### PR TITLE
Fix error when editing Pattern Blocks

### DIFF
--- a/src/components/AuthorsSelect.tsx
+++ b/src/components/AuthorsSelect.tsx
@@ -58,7 +58,7 @@ const AuthorsSelect = ( props: AuthorsSelectProps ): ReactElement => {
 
 	if ( ! selected.length && isEqual( preloadedAuthorIDs, currentAuthorIDs ) ) {
 		setSelected( preloadedAuthorOptions.authors );
-	} else if ( currentAuthorIDs.length && ! selected.length ) {
+	} else if ( currentAuthorIDs !== undefined && currentAuthorIDs.length && ! selected.length ) {
 
 		const path = addQueryArgs(
 			'/authorship/v1/users/',


### PR DESCRIPTION
When a user tries to edit a Block Pattern in the content itself, the plugin throws this error:

```
TypeError: Cannot read properties of undefined (reading 'length')
    at AuthorsSelect (AuthorsSelect.tsx:61:1)
    at wt (react-dom.min.js?ver=18.2.0:10:47637)
    at js (react-dom.min.js?ver=18.2.0:10:120584)
    at wl (react-dom.min.js?ver=18.2.0:10:88659)
    at bl (react-dom.min.js?ver=18.2.0:10:88587)
    at yl (react-dom.min.js?ver=18.2.0:10:88450)
    at il (react-dom.min.js?ver=18.2.0:10:85274)
    at fl (react-dom.min.js?ver=18.2.0:10:85661)
    at Nn (react-dom.min.js?ver=18.2.0:10:32474)
    at react-dom.min.js?ver=18.2.0:10:83226
```

Adding an extra check in a conditional fixed the problem.
