### PR TITLE
Update test-nightly.yml to use `dev-main`

### DIFF
--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Install PHP Dependencies
       run: |
         composer install --prefer-dist --no-progress --no-suggest --no-interaction --ignore-platform-reqs
-        composer require --dev --update-with-dependencies --prefer-dist roots/wordpress="dev-nightly" wp-phpunit/wp-phpunit="dev-master"
+        composer require --dev --update-with-dependencies --prefer-dist roots/wordpress="dev-main" wp-phpunit/wp-phpunit="dev-master"
 
     - name: Run the tests
       run: |


### PR DESCRIPTION
The roots/wordpress repo has dropped all branches except for `main`.

Fixes the nightly test runs.

Context: 

- https://github.com/roots/wordpress/issues/50
- https://roots.io/updates-to-roots-wordpress-composer-package/