### PR TITLE
Fix exit after WP_CLI::error

### DIFF
--- a/inc/cli/class-migrate-command.php
+++ b/inc/cli/class-migrate-command.php
@@ -260,7 +260,6 @@ class Migrate_Command extends WP_CLI_Command {
 				if ( is_wp_error( $ppa_terms ) ) {
 					WP_CLI::error( 'There was an error fetching the PublishPress Author data, is the plugin activated?', false );
 					WP_CLI::error( $ppa_terms );
-					exit;
 				}
 
 				/**
@@ -363,7 +362,6 @@ class Migrate_Command extends WP_CLI_Command {
 		if ( is_wp_error( $ppa_user_id ) ) {
 			WP_CLI::error( 'Could not create Authorship user with these arguments:' );
 			WP_CLI::error( $ppa_user_id );
-			return -1;
 		}
 
 		return $ppa_user_id;

--- a/inc/cli/class-migrate-command.php
+++ b/inc/cli/class-migrate-command.php
@@ -360,7 +360,7 @@ class Migrate_Command extends WP_CLI_Command {
 		// If this fails we want the debug data, so print out the
 		// arguments so we can reproduce later.
 		if ( is_wp_error( $ppa_user_id ) ) {
-			WP_CLI::error( 'Could not create Authorship user with these arguments:' );
+			WP_CLI::error( 'Could not create Authorship user with these arguments:', false );
 			WP_CLI::error( $ppa_user_id );
 		}
 

--- a/inc/cli/class-migrate-command.php
+++ b/inc/cli/class-migrate-command.php
@@ -259,7 +259,8 @@ class Migrate_Command extends WP_CLI_Command {
 				// Usually invalid taxonomy, lets catch and report this.
 				if ( is_wp_error( $ppa_terms ) ) {
 					WP_CLI::error( 'There was an error fetching the PublishPress Author data, is the plugin activated?', false );
-					WP_CLI::error( $ppa_terms );
+					WP_CLI::error( $ppa_terms, false );
+					exit;
 				}
 
 				/**
@@ -361,7 +362,8 @@ class Migrate_Command extends WP_CLI_Command {
 		// arguments so we can reproduce later.
 		if ( is_wp_error( $ppa_user_id ) ) {
 			WP_CLI::error( 'Could not create Authorship user with these arguments:', false );
-			WP_CLI::error( $ppa_user_id );
+			WP_CLI::error( $ppa_user_id, false );
+			exit;
 		}
 
 		return $ppa_user_id;

--- a/inc/cli/class-migrate-command.php
+++ b/inc/cli/class-migrate-command.php
@@ -260,7 +260,7 @@ class Migrate_Command extends WP_CLI_Command {
 				if ( is_wp_error( $ppa_terms ) ) {
 					WP_CLI::error( 'There was an error fetching the PublishPress Author data, is the plugin activated?', false );
 					WP_CLI::error( $ppa_terms, false );
-					exit;
+					exit( 1 );
 				}
 
 				/**

--- a/inc/cli/class-migrate-command.php
+++ b/inc/cli/class-migrate-command.php
@@ -363,7 +363,7 @@ class Migrate_Command extends WP_CLI_Command {
 		if ( is_wp_error( $ppa_user_id ) ) {
 			WP_CLI::error( 'Could not create Authorship user with these arguments:', false );
 			WP_CLI::error( $ppa_user_id, false );
-			exit;
+			exit( 1 );
 		}
 
 		return $ppa_user_id;


### PR DESCRIPTION
`WP_CLI::error` already exits.