### PR TITLE
Fix nightly builds minimum stability issue with Roots WP

### DIFF
--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Install PHP Dependencies
       run: |
         composer install --prefer-dist --no-progress --no-suggest --no-interaction --ignore-platform-reqs
-        composer require --dev --update-with-dependencies --prefer-dist roots/wordpress="dev-main" wp-phpunit/wp-phpunit="dev-master"
+        composer require --dev --update-with-all-dependencies --prefer-dist roots/wordpress="dev-main" roots/wordpress-no-content="dev-main" wp-phpunit/wp-phpunit="dev-master"
 
     - name: Run the tests
       run: |


### PR DESCRIPTION
The minimum stability requirement is blocking roots/wordpress from installing due to a sub dependency of roots/wordpress-no-content

Successful action run for this branch is here https://github.com/humanmade/authorship/actions/runs/10142036726