### PR TITLE
Update GH Action Ubuntu version to a supported one

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   wordpress:
     name: Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: Test the Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/php-standards.yml
+++ b/.github/workflows/php-standards.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: PHP Coding Standards
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -17,7 +17,7 @@ jobs:
           - '8.3'
       fail-fast: false
     name: WP nightly / PHP ${{ matrix.php }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           - '8.3'
       fail-fast: false
     name: WP 6.6 / PHP ${{ matrix.php }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4


### PR DESCRIPTION
Action runs are failing right now and reporting that the ubuntu version 20.04 is out of support.