### PR TITLE
do not modify rest responses, belonging to the WPML plugin

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -311,6 +311,11 @@ function filter_rest_request_after_callbacks( $result, array $handler, WP_REST_R
 		return $result;
 	}
 
+	// skip requests to wpml api
+	if(preg_match('/^\/wpml\//', $request->get_route())){
+		return $result;
+	}
+
 	$data = $result->get_data();
 
 	if ( ! is_array( $data ) || ! isset( $data[ REST_PARAM ] ) ) {


### PR DESCRIPTION
Fixes an issue, where WPMLs dashboard.js does not expect the _links object in its rest responses.

When opening the WPML dashboard under `wp-admin/admin.php?page=tm%2Fmenu%2Fmain.php` we get this js error.
```
TypeError: Cannot read properties of undefined (reading 'indexOf')
    at dashboard.js?ver=473900:1:40119
    at Array.filter (<anonymous>)
    at dashboard.js?ver=473900:1:40074
    at node-modules.js?ver=473900:2:57886
    at h (node-modules.js?ver=473900:2:56760)
    at node-modules.js?ver=473900:2:58019
    at h (node-modules.js?ver=473900:2:56760)
    at dashboard.js?ver=473900:1:452595
    at node-modules.js?ver=473900:2:255684
    at e (node-modules.js?ver=473900:2:287402)
```