### PR TITLE
Build-04: move editor init to effect and make CLI migration pause configurable

### DIFF
--- a/inc/cli/class-migrate-command.php
+++ b/inc/cli/class-migrate-command.php
@@ -55,6 +55,12 @@ class Migrate_Command extends WP_CLI_Command {
 	 * default: post
 	 * ---
 	 *
+	 * [--batch-pause=<batch-pause>]
+	 * : Seconds to pause between processed batches.
+	 * ---
+	 * default: 2
+	 * ---
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp authorship migrate wp-authors --dry-run=true
@@ -134,9 +140,7 @@ class Migrate_Command extends WP_CLI_Command {
 			// Avoid memory exhaustion issues.
 			$this->reset_local_object_cache();
 
-			// Pause for a moment to let the database catch up.
-			WP_CLI::line( sprintf( 'Processed %d posts, pausing for a breath...', $count ) );
-			sleep( 2 );
+			$this->pause_between_batches( $assoc_args, 'wp-authors', $count );
 
 			$paged++;
 		} while ( count( $posts ) );
@@ -177,6 +181,12 @@ class Migrate_Command extends WP_CLI_Command {
 	 * options:
 	 *   - true
 	 *   - false
+	 * ---
+	 *
+	 * [--batch-pause=<batch-pause>]
+	 * : Seconds to pause between processed batches.
+	 * ---
+	 * default: 2
 	 * ---
 	 *
 	 * ## EXAMPLES
@@ -294,9 +304,7 @@ class Migrate_Command extends WP_CLI_Command {
 			// Avoid memory exhaustion issues.
 			$this->reset_local_object_cache();
 
-			// Pause for a moment to let the database catch up.
-			WP_CLI::line( sprintf( 'Processed %d posts, pausing for a breath...', $count ) );
-			sleep( 2 );
+			$this->pause_between_batches( $assoc_args, 'ppa', $count );
 
 			$paged++;
 		} while ( count( $posts ) );
@@ -367,6 +375,68 @@ class Migrate_Command extends WP_CLI_Command {
 		}
 
 		return $ppa_user_id;
+	}
+
+	/**
+	 * Pause between migration batches.
+	 *
+	 * @param array<string,mixed> $assoc_args CLI assoc args.
+	 * @param string              $migration Migration subcommand identifier.
+	 * @param int                 $count Number of processed posts so far.
+	 */
+	private function pause_between_batches( array $assoc_args, string $migration, int $count ) : void {
+		$pause_seconds = $this->get_batch_pause_seconds( $assoc_args, $migration );
+
+		if ( $pause_seconds <= 0 ) {
+			WP_CLI::line( sprintf( 'Processed %d posts, continuing without pause.', $count ) );
+			return;
+		}
+
+		WP_CLI::line(
+			sprintf(
+				'Processed %1$d posts, pausing for %2$s second(s)...',
+				$count,
+				$pause_seconds
+			)
+		);
+
+		usleep( (int) round( $pause_seconds * 1000000 ) );
+	}
+
+	/**
+	 * Resolve pause seconds between migration batches.
+	 *
+	 * @param array<string,mixed> $assoc_args CLI assoc args.
+	 * @param string              $migration Migration subcommand identifier.
+	 *
+	 * @return float
+	 */
+	private function get_batch_pause_seconds( array $assoc_args, string $migration ) : float {
+		$pause_seconds = 2.0;
+		if ( isset( $assoc_args['batch-pause'] ) && is_numeric( $assoc_args['batch-pause'] ) ) {
+			$pause_seconds = floatval( $assoc_args['batch-pause'] );
+		}
+		$pause_seconds = max( 0.0, $pause_seconds );
+
+		/**
+		 * Filter the pause duration between migration batches.
+		 *
+		 * @param float               $pause_seconds Pause length in seconds.
+		 * @param string              $migration Migration subcommand identifier.
+		 * @param array<string,mixed> $assoc_args Original CLI assoc args.
+		 */
+		$pause_seconds = apply_filters(
+			'authorship_migrate_batch_pause_seconds',
+			$pause_seconds,
+			$migration,
+			$assoc_args
+		);
+
+		if ( ! is_numeric( $pause_seconds ) ) {
+			return 0.0;
+		}
+
+		return max( 0.0, floatval( $pause_seconds ) );
 	}
 
 	/**

--- a/src/components/AuthorsSelect.tsx
+++ b/src/components/AuthorsSelect.tsx
@@ -1,5 +1,5 @@
 import { get, isEqual } from 'lodash';
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement, useEffect, useRef, useState } from 'react';
 import { Styles } from 'react-select';
 import type {
 	WP_REST_API_Error,
@@ -53,30 +53,63 @@ const AuthorsSelect = ( props: AuthorsSelectProps ): ReactElement => {
 	const isDisabled = ! hasAssignAuthorAction;
 
 	const [ selected, setSelected ] = useState<Option[]>( [] );
+	const hasInitializedSelection = useRef<boolean>( false );
 
-	const preloadedAuthorIDs = preloadedAuthorOptions.authors.map( author => author.value );
+	useEffect( () => {
+		if ( hasInitializedSelection.current || selected.length ) {
+			return;
+		}
 
-	if ( ! selected.length && isEqual( preloadedAuthorIDs, currentAuthorIDs ) ) {
-		setSelected( preloadedAuthorOptions.authors );
-	} else if ( currentAuthorIDs !== undefined && currentAuthorIDs.length && ! selected.length ) {
+		const preloadedAuthorIDs = preloadedAuthorOptions.authors.map( author => author.value );
 
-		const path = addQueryArgs(
-			'/authorship/v1/users/',
-			{
-				include: currentAuthorIDs,
-				orderby: 'include',
-				post_type: postType,
-			}
-		);
+		if ( isEqual( preloadedAuthorIDs, currentAuthorIDs ) ) {
+			setSelected( preloadedAuthorOptions.authors );
+			hasInitializedSelection.current = true;
+			return;
+		}
 
-		const api: Promise<WP_REST_API_User[]> = apiFetch( { path } );
+		if ( currentAuthorIDs !== undefined && currentAuthorIDs.length ) {
+			hasInitializedSelection.current = true;
 
-		api.then( users => {
-			setSelected( users.map( createOption ) );
-		} ).catch( ( error: WP_REST_API_Error ) => {
-			onError( error.message );
-		} );
-	}
+			const path = addQueryArgs(
+				'/authorship/v1/users/',
+				{
+					include: currentAuthorIDs,
+					orderby: 'include',
+					post_type: postType,
+				}
+			);
+
+			let isCancelled = false;
+			const api: Promise<WP_REST_API_User[]> = apiFetch( { path } );
+
+			api.then( users => {
+				if ( isCancelled ) {
+					return;
+				}
+
+				setSelected( users.map( createOption ) );
+			} ).catch( ( error: WP_REST_API_Error ) => {
+				if ( isCancelled ) {
+					return;
+				}
+
+				onError( error.message );
+			} );
+
+			return () => {
+				isCancelled = true;
+			};
+		}
+
+		hasInitializedSelection.current = true;
+	}, [
+		currentAuthorIDs,
+		onError,
+		postType,
+		preloadedAuthorOptions.authors,
+		selected.length,
+	] );
 
 	/**
 	 * Asynchronously loads the options for the control based on the search parameter.

--- a/tests/phpunit/test-cli.php
+++ b/tests/phpunit/test-cli.php
@@ -40,6 +40,7 @@ class TestCLI extends TestCase {
 		$command->wp_authors( [], [
 			'dry-run' => false,
 			'post-type' => 'post', // Note, have to set default values manually.
+			'batch-pause' => '0',
 		] );
 
 		// Check migration command has correctly set the author.
@@ -68,11 +69,38 @@ class TestCLI extends TestCase {
 		$command->wp_authors( [], [
 			'dry-run' => false,
 			'post-type' => 'post,page',
+			'batch-pause' => '0',
 		] );
 
 		// Check migration command has correctly set the author.
 		$authorship_authors = \Authorship\get_authors( $page1 );
 		$this->assertCount( 1, $authorship_authors );
 		$this->assertSame( self::$users['editor']->ID, $authorship_authors[0]->ID );
+	}
+
+	public function testMigrateRespectsZeroBatchPause() : void {
+		$factory = self::factory()->post;
+
+		$post = $factory->create_and_get( [
+			'post_author' => self::$users['editor']->ID,
+		] );
+
+		wp_set_post_terms( $post->ID, [], TAXONOMY );
+
+		$command = new CLI\Migrate_Command();
+
+		$start_time = microtime( true );
+		$command->wp_authors( [], [
+			'dry-run' => true,
+			'post-type' => 'post',
+			'batch-pause' => '0',
+		] );
+		$elapsed = microtime( true ) - $start_time;
+
+		$this->assertLessThan(
+			1.5,
+			$elapsed,
+			'Expected wp authors migration to skip fixed delay when batch-pause is zero.'
+		);
 	}
 }


### PR DESCRIPTION
## Summary
- move `AuthorsSelect` preload/fetch initialization out of render-time conditionals and into `useEffect`
- keep selection initialization one-time and guard async updates against unmounts
- add `--batch-pause` to `wp authorship migrate` commands and support `authorship_migrate_batch_pause_seconds` filtering
- add CLI coverage for zero pause behavior and remove fixed wait from existing CLI tests

## Why
This isolates the Build-04 performance/react-correctness work into a focused, reviewable PR:
- avoids render-time side effects in the editor
- removes hard-coded two-second migration pacing without changing default behavior

## Testing
- `npm run lint:js`
- `vendor/bin/phpunit --filter TestCLI` (assertions pass; this local PHP 8.5 environment still emits legacy deprecation/output noise marked as risky)
