### PR TITLE
REST hardening: guest-author creation and post-insert observability

### DIFF
--- a/inc/class-insert-post-handler.php
+++ b/inc/class-insert-post-handler.php
@@ -49,10 +49,11 @@ class InsertPostHandler {
 	 */
 	function action_wp_insert_post( int $post_ID, WP_Post $post, bool $update ) : void {
 		$unsanitized_postarr = $this->postarr;
+		$tax_input           = $unsanitized_postarr['tax_input'] ?? null;
 
 		$this->postarr = [];
 
-		if ( isset( $unsanitized_postarr['tax_input'] ) && ! empty( $unsanitized_postarr['tax_input'][ TAXONOMY ] ) ) {
+		if ( is_array( $tax_input ) && ! empty( $tax_input[ TAXONOMY ] ) ) {
 			return;
 		}
 
@@ -82,10 +83,21 @@ class InsertPostHandler {
 			return;
 		}
 
+		$author_ids = wp_parse_id_list( $authors );
+
 		try {
-			set_authors( $post, wp_parse_id_list( $authors ) );
+			set_authors( $post, $author_ids );
 		} catch ( Exception $e ) {
-			// Nothing at the moment.
+			/**
+			 * Fires when assigning authors to a post fails during insert/update.
+			 *
+			 * @param int       $post_ID    Post ID.
+			 * @param WP_Post   $post       Post object.
+			 * @param bool      $update     Whether this is an existing post being updated.
+			 * @param int[]     $author_ids Parsed list of requested author IDs.
+			 * @param Exception $e          Exception thrown while assigning authors.
+			 */
+			do_action( 'authorship_author_assignment_failure', $post_ID, $post, $update, $author_ids, $e );
 		}
 	}
 }

--- a/inc/class-users-controller.php
+++ b/inc/class-users-controller.php
@@ -29,6 +29,8 @@ class Users_Controller extends WP_REST_Users_Controller {
 
 	const _NAMESPACE = 'authorship/v1';
 	const BASE = 'users';
+	const DEFAULT_GUEST_USERNAME = 'guestauthor';
+	const MAX_USERNAME_LENGTH = 60;
 
 	/**
 	 * Constructor.
@@ -191,8 +193,10 @@ class Users_Controller extends WP_REST_Users_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function create_item( $request ) {
-		$username = sanitize_title( sanitize_user( $request->get_param( 'name' ), true ) );
-		$username = preg_replace( '/[^a-z0-9]/', '', $username );
+		$name_param = $request->get_param( 'name' );
+		$name       = is_string( $name_param ) ? $name_param : '';
+		$username   = $this->normalize_guest_username( $name );
+		$username   = $this->get_unique_guest_username( $username );
 
 		$request->set_param( 'username', $username );
 
@@ -208,15 +212,65 @@ class Users_Controller extends WP_REST_Users_Controller {
 		 *     @type WP_Error $errors        WP_Error object containing any errors found.
 		 * }
 		 */
-		add_filter( 'wpmu_validate_user_signup', function( array $result ) : array {
-			/** @var WP_Error $errors */
-			$errors = $result['errors'];
-			$errors->remove( 'user_email' );
+		add_filter( 'wpmu_validate_user_signup', [ $this, 'filter_guest_author_signup_validation' ] );
 
-			return $result;
-		} );
+		try {
+			return parent::create_item( $request );
+		} finally {
+			remove_filter( 'wpmu_validate_user_signup', [ $this, 'filter_guest_author_signup_validation' ] );
+		}
+	}
 
-		return parent::create_item( $request );
+	/**
+	 * Filters validated signup data for guest author creation.
+	 *
+	 * @param mixed[] $result Signup validation result.
+	 * @return mixed[] Signup validation result.
+	 */
+	public function filter_guest_author_signup_validation( array $result ) : array {
+		if ( isset( $result['errors'] ) && $result['errors'] instanceof WP_Error ) {
+			$result['errors']->remove( 'user_email' );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Normalizes a guest author username from the provided name.
+	 *
+	 * @param string $name Guest author display name.
+	 * @return string Normalized username candidate.
+	 */
+	protected function normalize_guest_username( string $name ) : string {
+		$username = sanitize_title( sanitize_user( $name, true ) );
+		$username = preg_replace( '/[^a-z0-9]/', '', $username );
+
+		if ( ! is_string( $username ) || '' === $username ) {
+			$username = self::DEFAULT_GUEST_USERNAME;
+		}
+
+		return substr( $username, 0, self::MAX_USERNAME_LENGTH );
+	}
+
+	/**
+	 * Ensures the guest author username is unique.
+	 *
+	 * @param string $username Username candidate.
+	 * @return string Unique username.
+	 */
+	protected function get_unique_guest_username( string $username ) : string {
+		$candidate = $username;
+		$suffix    = 2;
+
+		while ( username_exists( $candidate ) ) {
+			$suffix_string   = (string) $suffix;
+			$max_base_length = max( 1, self::MAX_USERNAME_LENGTH - strlen( $suffix_string ) );
+			$base            = substr( $username, 0, $max_base_length );
+			$candidate       = "{$base}{$suffix_string}";
+			++$suffix;
+		}
+
+		return $candidate;
 	}
 
 	/**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -130,11 +130,17 @@ function filter_map_meta_cap_for_editing( array $caps, string $cap, int $user_id
 		return $caps;
 	}
 
-	if ( empty( $user_id ) || empty( $args[0] ) ) {
+	if ( empty( $user_id ) || ! isset( $args[0] ) || ! is_numeric( $args[0] ) ) {
 		return $caps;
 	}
+	$post_id = (int) $args[0];
+
+	if ( $post_id <= 0 ) {
+		return $caps;
+	}
+
 	$user = get_userdata( $user_id );
-	$post = get_post( $args[0] );
+	$post = get_post( $post_id );
 
 	if ( empty( $user ) || empty( $post ) ) {
 		return $caps;
@@ -238,7 +244,11 @@ function filter_map_meta_cap_for_editing( array $caps, string $cap, int $user_id
  * @return bool[] Array of concerned user's capabilities.
  */
 function filter_user_has_cap( array $user_caps, array $required_caps, array $args, WP_User $user ) : array {
-	$cap = $args[0];
+	$cap = isset( $args[0] ) && is_string( $args[0] ) ? $args[0] : '';
+
+	if ( '' === $cap ) {
+		return $user_caps;
+	}
 
 	switch ( $cap ) {
 
@@ -249,7 +259,7 @@ function filter_user_has_cap( array $user_caps, array $required_caps, array $arg
 			break;
 
 		case 'attribute_post_type':
-			if ( empty( $args[2] ) ) {
+			if ( empty( $args[2] ) || ! is_string( $args[2] ) ) {
 				$user_caps[ $cap ] = false;
 				break;
 			}
@@ -287,7 +297,10 @@ function filter_user_has_cap( array $user_caps, array $required_caps, array $arg
  */
 function action_wp( WP $wp ) : void {
 	if ( is_author() ) {
-		$GLOBALS['authordata'] = get_userdata( get_query_var( 'author' ) );
+		$author_id = get_query_var( 'author' );
+		$author_id = is_numeric( $author_id ) ? (int) $author_id : 0;
+
+		$GLOBALS['authordata'] = get_userdata( $author_id );
 	}
 }
 
@@ -378,6 +391,12 @@ function validate_authors( $authors, WP_REST_Request $request, string $param, st
 
 	// The REST API accepts and coerces a comma-separated string as an array, so
 	// we need to allow for that here.
+	if ( ! is_array( $authors ) && ! is_string( $authors ) ) {
+		return new WP_Error( 'authorship', __( 'The authors payload must be an array or comma-separated string.', 'authorship' ), [
+			'status' => WP_Http::BAD_REQUEST,
+		] );
+	}
+
 	$authors = wp_parse_id_list( $authors );
 
 	/** @var WP_User[] */
@@ -472,8 +491,8 @@ function rest_prepare_post( WP_REST_Response $response, WP_Post $post, WP_REST_R
 /**
  * Filters extra CURIEs available on REST API responses.
  *
- * @param array[] $additional Additional CURIEs to register with the API.
- * @return array[] Additional CURIEs to register with the API.
+ * @param array<int,array{name:string,href:string,templated:bool}> $additional Additional CURIEs to register with the API.
+ * @return array<int,array{name:string,href:string,templated:bool}> Additional CURIEs to register with the API.
  */
 function filter_rest_response_link_curies( array $additional ) : array {
 	$additional[] = [
@@ -504,33 +523,76 @@ function enqueue_assets() : void {
  * Enqueues the JS and CSS assets for the author selection control.
  */
 function enqueue_assets_for_post() : void {
-	$manifest = plugin_dir_path( __DIR__ ) . 'build/asset-manifest.json';
+	$plugin_dir = plugin_dir_path( __DIR__ );
+	$plugin_url = plugin_dir_url( __DIR__ );
+	$manifest   = $plugin_dir . 'build/asset-manifest.json';
 
-	enqueue_asset(
-		$manifest,
-		'main.js',
-		[
-			'handle'       => SCRIPT_HANDLE,
-			// @TODO check:
-			'dependencies' => [
-				'react',
-				'wp-block-editor',
-				'wp-blocks',
-				'wp-components',
-				'wp-element',
-				'wp-i18n',
-				'wp-polyfill',
-			],
-		]
-	);
+	$script_dependencies = [
+		'lodash',
+		'react',
+		'wp-api-fetch',
+		'wp-block-editor',
+		'wp-blocks',
+		'wp-compose',
+		'wp-components',
+		'wp-data',
+		'wp-edit-post',
+		'wp-element',
+		'wp-i18n',
+		'wp-plugins',
+		'wp-polyfill',
+		'wp-url',
+	];
 
-	enqueue_asset(
-		$manifest,
-		'style.css',
-		[
-			'handle' => STYLE_HANDLE,
-		]
-	);
+	if ( file_exists( $manifest ) ) {
+		enqueue_asset(
+			$manifest,
+			'main.js',
+			[
+				'handle'       => SCRIPT_HANDLE,
+				'dependencies' => $script_dependencies,
+			]
+		);
+
+		enqueue_asset(
+			$manifest,
+			'style.css',
+			[
+				'handle' => STYLE_HANDLE,
+			]
+		);
+
+		return;
+	}
+
+	$script_relative_path = 'build/main.js';
+	$script_path          = $plugin_dir . $script_relative_path;
+
+	if ( file_exists( $script_path ) ) {
+		$script_version = filemtime( $script_path );
+
+		wp_enqueue_script(
+			SCRIPT_HANDLE,
+			$plugin_url . $script_relative_path,
+			$script_dependencies,
+			false !== $script_version ? (string) $script_version : null,
+			true
+		);
+	}
+
+	$style_relative_path = 'build/style.css';
+	$style_path          = $plugin_dir . $style_relative_path;
+
+	if ( file_exists( $style_path ) ) {
+		$style_version = filemtime( $style_path );
+
+		wp_enqueue_style(
+			STYLE_HANDLE,
+			$plugin_url . $style_relative_path,
+			[],
+			false !== $style_version ? (string) $style_version : null
+		);
+	}
 }
 
 /**
@@ -605,7 +667,7 @@ function action_pre_get_posts( WP_Query $query ) : void {
 		if ( ! empty( $value ) ) {
 			$stored_values[ $concern ] = $value;
 			$query->set( $concern, $concern_default_value );
-		}
+		}//end if
 	}
 
 	// None of the set query vars concern us? Then we have nothing more to do.
@@ -619,30 +681,54 @@ function action_pre_get_posts( WP_Query $query ) : void {
 	// as WP_Query will handle the validation before constructing its query.
 	if ( ! empty( $stored_values['author'] ) ) {
 		if ( is_string( $stored_values['author'] ) ) {
-			$user_ids = array_map( 'intval', explode( ',', $stored_values['author'] ) );
+			$user_ids = array_map(
+				static function( $id ) : int {
+					return (int) $id;
+				},
+				explode( ',', $stored_values['author'] )
+			);
 		} elseif ( is_numeric( $stored_values['author'] ) ) {
 			$user_ids = [ (int) $stored_values['author'] ];
-		}
+		}//end if
 	} elseif ( ! empty( $stored_values['author_name'] ) ) {
-		$user = get_user_by( 'slug', $stored_values['author_name'] );
+		if ( is_string( $stored_values['author_name'] ) ) {
+			$user = get_user_by( 'slug', $stored_values['author_name'] );
 
-		if ( $user ) {
-			$user_ids = [ $user->ID ];
-		}
+			if ( $user ) {
+				$user_ids = [ $user->ID ];
+			}
+		}//end if
 	} elseif ( ! empty( $stored_values['author__in'] ) ) {
-		$user_ids = array_map( 'intval', $stored_values['author__in'] );
+		if ( is_array( $stored_values['author__in'] ) ) {
+			$user_ids = array_map(
+				static function( $id ) : int {
+					return (int) $id;
+				},
+				$stored_values['author__in']
+			);
+		}
 	} elseif ( ! empty( $stored_values['author__not_in'] ) ) {
-		$user_ids = array_map( function( int $id ) : int {
-			return $id * -1;
-		}, array_map( 'intval', $stored_values['author__not_in'] ) );
-	}
+		if ( is_array( $stored_values['author__not_in'] ) ) {
+			$user_ids = array_map(
+				static function( int $id ) : int {
+					return $id * -1;
+				},
+				array_map(
+					static function( $id ) : int {
+						return (int) $id;
+					},
+					$stored_values['author__not_in']
+				)
+			);
+		}
+	}//end if
 
 	$tax_query = $query->get( 'tax_query' );
 
 	// Record the value of an existing tax query, if there is one.
 	$stored_values['tax_query'] = $tax_query;
 
-	if ( empty( $tax_query ) ) {
+	if ( ! is_array( $tax_query ) ) {
 		$tax_query = [];
 	}
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -130,17 +130,11 @@ function filter_map_meta_cap_for_editing( array $caps, string $cap, int $user_id
 		return $caps;
 	}
 
-	if ( empty( $user_id ) || ! isset( $args[0] ) || ! is_numeric( $args[0] ) ) {
+	if ( empty( $user_id ) || empty( $args[0] ) ) {
 		return $caps;
 	}
-	$post_id = (int) $args[0];
-
-	if ( $post_id <= 0 ) {
-		return $caps;
-	}
-
 	$user = get_userdata( $user_id );
-	$post = get_post( $post_id );
+	$post = get_post( $args[0] );
 
 	if ( empty( $user ) || empty( $post ) ) {
 		return $caps;
@@ -244,11 +238,7 @@ function filter_map_meta_cap_for_editing( array $caps, string $cap, int $user_id
  * @return bool[] Array of concerned user's capabilities.
  */
 function filter_user_has_cap( array $user_caps, array $required_caps, array $args, WP_User $user ) : array {
-	$cap = isset( $args[0] ) && is_string( $args[0] ) ? $args[0] : '';
-
-	if ( '' === $cap ) {
-		return $user_caps;
-	}
+	$cap = $args[0];
 
 	switch ( $cap ) {
 
@@ -259,7 +249,7 @@ function filter_user_has_cap( array $user_caps, array $required_caps, array $arg
 			break;
 
 		case 'attribute_post_type':
-			if ( empty( $args[2] ) || ! is_string( $args[2] ) ) {
+			if ( empty( $args[2] ) ) {
 				$user_caps[ $cap ] = false;
 				break;
 			}
@@ -297,10 +287,7 @@ function filter_user_has_cap( array $user_caps, array $required_caps, array $arg
  */
 function action_wp( WP $wp ) : void {
 	if ( is_author() ) {
-		$author_id = get_query_var( 'author' );
-		$author_id = is_numeric( $author_id ) ? (int) $author_id : 0;
-
-		$GLOBALS['authordata'] = get_userdata( $author_id );
+		$GLOBALS['authordata'] = get_userdata( get_query_var( 'author' ) );
 	}
 }
 
@@ -391,12 +378,6 @@ function validate_authors( $authors, WP_REST_Request $request, string $param, st
 
 	// The REST API accepts and coerces a comma-separated string as an array, so
 	// we need to allow for that here.
-	if ( ! is_array( $authors ) && ! is_string( $authors ) ) {
-		return new WP_Error( 'authorship', __( 'The authors payload must be an array or comma-separated string.', 'authorship' ), [
-			'status' => WP_Http::BAD_REQUEST,
-		] );
-	}
-
 	$authors = wp_parse_id_list( $authors );
 
 	/** @var WP_User[] */
@@ -491,8 +472,8 @@ function rest_prepare_post( WP_REST_Response $response, WP_Post $post, WP_REST_R
 /**
  * Filters extra CURIEs available on REST API responses.
  *
- * @param array<int,array{name:string,href:string,templated:bool}> $additional Additional CURIEs to register with the API.
- * @return array<int,array{name:string,href:string,templated:bool}> Additional CURIEs to register with the API.
+ * @param array[] $additional Additional CURIEs to register with the API.
+ * @return array[] Additional CURIEs to register with the API.
  */
 function filter_rest_response_link_curies( array $additional ) : array {
 	$additional[] = [
@@ -523,76 +504,33 @@ function enqueue_assets() : void {
  * Enqueues the JS and CSS assets for the author selection control.
  */
 function enqueue_assets_for_post() : void {
-	$plugin_dir = plugin_dir_path( __DIR__ );
-	$plugin_url = plugin_dir_url( __DIR__ );
-	$manifest   = $plugin_dir . 'build/asset-manifest.json';
+	$manifest = plugin_dir_path( __DIR__ ) . 'build/asset-manifest.json';
 
-	$script_dependencies = [
-		'lodash',
-		'react',
-		'wp-api-fetch',
-		'wp-block-editor',
-		'wp-blocks',
-		'wp-compose',
-		'wp-components',
-		'wp-data',
-		'wp-edit-post',
-		'wp-element',
-		'wp-i18n',
-		'wp-plugins',
-		'wp-polyfill',
-		'wp-url',
-	];
+	enqueue_asset(
+		$manifest,
+		'main.js',
+		[
+			'handle'       => SCRIPT_HANDLE,
+			// @TODO check:
+			'dependencies' => [
+				'react',
+				'wp-block-editor',
+				'wp-blocks',
+				'wp-components',
+				'wp-element',
+				'wp-i18n',
+				'wp-polyfill',
+			],
+		]
+	);
 
-	if ( file_exists( $manifest ) ) {
-		enqueue_asset(
-			$manifest,
-			'main.js',
-			[
-				'handle'       => SCRIPT_HANDLE,
-				'dependencies' => $script_dependencies,
-			]
-		);
-
-		enqueue_asset(
-			$manifest,
-			'style.css',
-			[
-				'handle' => STYLE_HANDLE,
-			]
-		);
-
-		return;
-	}
-
-	$script_relative_path = 'build/main.js';
-	$script_path          = $plugin_dir . $script_relative_path;
-
-	if ( file_exists( $script_path ) ) {
-		$script_version = filemtime( $script_path );
-
-		wp_enqueue_script(
-			SCRIPT_HANDLE,
-			$plugin_url . $script_relative_path,
-			$script_dependencies,
-			false !== $script_version ? (string) $script_version : null,
-			true
-		);
-	}
-
-	$style_relative_path = 'build/style.css';
-	$style_path          = $plugin_dir . $style_relative_path;
-
-	if ( file_exists( $style_path ) ) {
-		$style_version = filemtime( $style_path );
-
-		wp_enqueue_style(
-			STYLE_HANDLE,
-			$plugin_url . $style_relative_path,
-			[],
-			false !== $style_version ? (string) $style_version : null
-		);
-	}
+	enqueue_asset(
+		$manifest,
+		'style.css',
+		[
+			'handle' => STYLE_HANDLE,
+		]
+	);
 }
 
 /**
@@ -667,7 +605,7 @@ function action_pre_get_posts( WP_Query $query ) : void {
 		if ( ! empty( $value ) ) {
 			$stored_values[ $concern ] = $value;
 			$query->set( $concern, $concern_default_value );
-		}//end if
+		}
 	}
 
 	// None of the set query vars concern us? Then we have nothing more to do.
@@ -681,54 +619,30 @@ function action_pre_get_posts( WP_Query $query ) : void {
 	// as WP_Query will handle the validation before constructing its query.
 	if ( ! empty( $stored_values['author'] ) ) {
 		if ( is_string( $stored_values['author'] ) ) {
-			$user_ids = array_map(
-				static function( $id ) : int {
-					return (int) $id;
-				},
-				explode( ',', $stored_values['author'] )
-			);
+			$user_ids = array_map( 'intval', explode( ',', $stored_values['author'] ) );
 		} elseif ( is_numeric( $stored_values['author'] ) ) {
 			$user_ids = [ (int) $stored_values['author'] ];
-		}//end if
+		}
 	} elseif ( ! empty( $stored_values['author_name'] ) ) {
-		if ( is_string( $stored_values['author_name'] ) ) {
-			$user = get_user_by( 'slug', $stored_values['author_name'] );
+		$user = get_user_by( 'slug', $stored_values['author_name'] );
 
-			if ( $user ) {
-				$user_ids = [ $user->ID ];
-			}
-		}//end if
+		if ( $user ) {
+			$user_ids = [ $user->ID ];
+		}
 	} elseif ( ! empty( $stored_values['author__in'] ) ) {
-		if ( is_array( $stored_values['author__in'] ) ) {
-			$user_ids = array_map(
-				static function( $id ) : int {
-					return (int) $id;
-				},
-				$stored_values['author__in']
-			);
-		}
+		$user_ids = array_map( 'intval', $stored_values['author__in'] );
 	} elseif ( ! empty( $stored_values['author__not_in'] ) ) {
-		if ( is_array( $stored_values['author__not_in'] ) ) {
-			$user_ids = array_map(
-				static function( int $id ) : int {
-					return $id * -1;
-				},
-				array_map(
-					static function( $id ) : int {
-						return (int) $id;
-					},
-					$stored_values['author__not_in']
-				)
-			);
-		}
-	}//end if
+		$user_ids = array_map( function( int $id ) : int {
+			return $id * -1;
+		}, array_map( 'intval', $stored_values['author__not_in'] ) );
+	}
 
 	$tax_query = $query->get( 'tax_query' );
 
 	// Record the value of an existing tax query, if there is one.
 	$stored_values['tax_query'] = $tax_query;
 
-	if ( ! is_array( $tax_query ) ) {
+	if ( empty( $tax_query ) ) {
 		$tax_query = [];
 	}
 

--- a/tests/phpunit/test-post-saving.php
+++ b/tests/phpunit/test-post-saving.php
@@ -153,4 +153,40 @@ class TestPostSaving extends TestCase {
 
 		$this->assertSame( $before, $after );
 	}
+
+	public function testAuthorAssignmentFailureIsSignaledOnInsert() : void {
+		$failures = [];
+
+		$callback = function( int $post_id, \WP_Post $post, bool $update, array $author_ids, \Exception $exception ) use ( &$failures ) : void {
+			$failures[] = [
+				'post_id'    => $post_id,
+				'post'       => $post,
+				'update'     => $update,
+				'author_ids' => $author_ids,
+				'exception'  => $exception,
+			];
+		};
+
+		add_action( 'authorship_author_assignment_failure', $callback, 10, 5 );
+
+		$post_id = wp_insert_post(
+			[
+				'post_title'  => 'Observable assignment failure',
+				'post_author' => self::$users['author']->ID,
+				POSTS_PARAM   => [ 999999 ],
+			],
+			true
+		);
+
+		remove_action( 'authorship_author_assignment_failure', $callback, 10 );
+
+		$this->assertIsInt( $post_id );
+		$this->assertGreaterThan( 0, $post_id );
+		$this->assertCount( 1, $failures );
+		$this->assertSame( $post_id, $failures[0]['post_id'] );
+		$this->assertFalse( $failures[0]['update'] );
+		$this->assertSame( [ 999999 ], $failures[0]['author_ids'] );
+		$this->assertInstanceOf( \Exception::class, $failures[0]['exception'] );
+		$this->assertSame( 'One or more user IDs are not valid for this site.', $failures[0]['exception']->getMessage() );
+	}
 }

--- a/tests/phpunit/test-rest-api-user-endpoint.php
+++ b/tests/phpunit/test-rest-api-user-endpoint.php
@@ -41,6 +41,53 @@ class TestRESTAPIUserEndpoint extends RESTAPITestCase {
 		$this->assertSame( [ GUEST_ROLE ], $data['roles'] );
 	}
 
+	public function testGuestAuthorDuplicateNameGetsUniqueUsername() : void {
+		wp_set_current_user( self::$users['editor']->ID );
+
+		$request = new WP_REST_Request( 'POST', self::$route );
+		$request->set_param( 'name', 'Duplicate Name' );
+
+		$first_response = self::rest_do_request( $request );
+		$first_data     = $first_response->get_data();
+		$first_message  = self::get_message( $first_response );
+
+		$this->assertSame( WP_Http::CREATED, $first_response->get_status(), $first_message );
+
+		$request = new WP_REST_Request( 'POST', self::$route );
+		$request->set_param( 'name', 'Duplicate Name' );
+
+		$second_response = self::rest_do_request( $request );
+		$second_data     = $second_response->get_data();
+		$second_message  = self::get_message( $second_response );
+
+		$this->assertSame( WP_Http::CREATED, $second_response->get_status(), $second_message );
+
+		$first_user  = get_userdata( (int) $first_data['id'] );
+		$second_user = get_userdata( (int) $second_data['id'] );
+
+		$this->assertNotFalse( $first_user );
+		$this->assertNotFalse( $second_user );
+		$this->assertSame( 'duplicatename', $first_user->user_login );
+		$this->assertMatchesRegularExpression( '/^duplicatename[0-9]+$/', $second_user->user_login );
+	}
+
+	public function testGuestAuthorNonAsciiNameGetsFallbackUsername() : void {
+		wp_set_current_user( self::$users['editor']->ID );
+
+		$request = new WP_REST_Request( 'POST', self::$route );
+		$request->set_param( 'name', '李小龍' );
+
+		$response = self::rest_do_request( $request );
+		$data     = $response->get_data();
+		$message  = self::get_message( $response );
+
+		$this->assertSame( WP_Http::CREATED, $response->get_status(), $message );
+
+		$user = get_userdata( (int) $data['id'] );
+		$this->assertNotFalse( $user );
+		$this->assertMatchesRegularExpression( '/^guestauthor(?:-[0-9]+)?$/', $user->user_login );
+	}
+
 	/**
 	 * @dataProvider dataDisallowedFields
 	 *


### PR DESCRIPTION
## Summary
- harden guest-author username handling in the REST user endpoint
- improve collision handling when generating guest-author usernames
- add failure observability for post insert author assignment path
- extend tests for both guest-author creation and post-save error handling

## Files
- `inc/class-users-controller.php`
- `inc/class-insert-post-handler.php`
- `tests/phpunit/test-rest-api-user-endpoint.php`
- `tests/phpunit/test-post-saving.php`

## Verification
- `composer test:ut` (pass; upstream test suite currently emits deprecation/risky noise under PHP 8.5)

## Notes
- This PR intentionally excludes CLI and editor changes.
