### PR TITLE
CLI migrations: pacing controls and post-type normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,21 @@ The command will perform a dry run by default, setting `--dry-run=false` will ma
 
 This command will not overwrite or update Authorship data unless the `--overwrite-authors=true` flag is set.
 
+### Migration pacing controls
+
+Both migration commands support `--batch-pause=<seconds>` (default `2`).
+Set `--batch-pause=0` to run without intentional pauses between processed batches.
+
+Authorship also provides hook extension points for migration pacing:
+
+* `authorship_migrate_batch_pause_seconds` filter
+  * Parameters: `(float $pause_seconds, string $migration, array $assoc_args)`
+  * Return a numeric pause value in seconds.
+* `authorship_migrate_batch_pause_resolved` action
+  * Parameters: `(float $pause_seconds, string $migration, array $assoc_args, int $count)`
+  * Fires after pause resolution and before optional sleeping for each processed batch.
+  * Does not fire for batches that process zero posts.
+
 ## Email Notifications
 
 Authorship does not send any email notifications itself, but it does instruct WordPress core to additionally send its emails to attributed authors when appropriate.

--- a/inc/cli/class-migrate-command.php
+++ b/inc/cli/class-migrate-command.php
@@ -55,6 +55,12 @@ class Migrate_Command extends WP_CLI_Command {
 	 * default: post
 	 * ---
 	 *
+	 * [--batch-pause=<batch-pause>]
+	 * : Seconds to pause between processed batches.
+	 * ---
+	 * default: 2
+	 * ---
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp authorship migrate wp-authors --dry-run=true
@@ -85,7 +91,7 @@ class Migrate_Command extends WP_CLI_Command {
 			WP_CLI::warning( 'Overwriting of previous Authorship data is set to true.' );
 		}
 
-		$post_types = explode( ',', $assoc_args['post-type'] );
+		$post_types = $this->get_migration_post_types( $assoc_args );
 		WP_CLI::line( sprintf( 'Updating post types: %s', implode( ', ', $post_types ) ) );
 
 		$tax_query = $overwrite ? [] : [
@@ -114,6 +120,8 @@ class Migrate_Command extends WP_CLI_Command {
 				break;
 			}
 
+			$processed_in_batch = 0;
+
 			foreach ( $posts as $post ) {
 				$authorship_authors = \Authorship\get_authors( $post );
 
@@ -129,14 +137,13 @@ class Migrate_Command extends WP_CLI_Command {
 				}
 
 				$count++;
+				$processed_in_batch++;
 			}//end foreach
 
 			// Avoid memory exhaustion issues.
 			$this->reset_local_object_cache();
 
-			// Pause for a moment to let the database catch up.
-			WP_CLI::line( sprintf( 'Processed %d posts, pausing for a breath...', $count ) );
-			sleep( 2 );
+			$this->pause_between_batches( $assoc_args, 'wp-authors', $count, $processed_in_batch );
 
 			$paged++;
 		} while ( count( $posts ) );
@@ -179,6 +186,12 @@ class Migrate_Command extends WP_CLI_Command {
 	 *   - false
 	 * ---
 	 *
+	 * [--batch-pause=<batch-pause>]
+	 * : Seconds to pause between processed batches.
+	 * ---
+	 * default: 2
+	 * ---
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp authorship migrate ppa --dry-run=true
@@ -191,7 +204,15 @@ class Migrate_Command extends WP_CLI_Command {
 	function ppa( $args, $assoc_args ) : void {
 		if ( ! taxonomy_exists( 'author' ) ) {
 			// register the `author` taxonomy so that we can query for PPA author terms.
-			register_taxonomy( 'author', 'post' );
+			register_taxonomy(
+				'author',
+				'post',
+				[
+					'public'    => false,
+					'query_var' => false,
+					'rewrite'   => false,
+				]
+			);
 		}
 
 		$posts_per_page = 100;
@@ -236,6 +257,8 @@ class Migrate_Command extends WP_CLI_Command {
 				break;
 			}
 
+			$processed_in_batch = 0;
+
 			foreach ( $posts as $post ) {
 				$authorship_authors = \Authorship\get_authors( $post );
 
@@ -258,9 +281,12 @@ class Migrate_Command extends WP_CLI_Command {
 				// If PPA is deactivated the terms can be an error object.
 				// Usually invalid taxonomy, lets catch and report this.
 				if ( is_wp_error( $ppa_terms ) ) {
-					WP_CLI::error( 'There was an error fetching the PublishPress Author data, is the plugin activated?', false );
-					WP_CLI::error( $ppa_terms, false );
-					exit( 1 );
+					WP_CLI::error(
+						sprintf(
+							'There was an error fetching the PublishPress Author data, is the plugin activated? (%s)',
+							$ppa_terms->get_error_message()
+						)
+					);
 				}
 
 				/**
@@ -289,14 +315,13 @@ class Migrate_Command extends WP_CLI_Command {
 				}
 
 				$count++;
+				$processed_in_batch++;
 			}//end foreach
 
 			// Avoid memory exhaustion issues.
 			$this->reset_local_object_cache();
 
-			// Pause for a moment to let the database catch up.
-			WP_CLI::line( sprintf( 'Processed %d posts, pausing for a breath...', $count ) );
-			sleep( 2 );
+			$this->pause_between_batches( $assoc_args, 'ppa', $count, $processed_in_batch );
 
 			$paged++;
 		} while ( count( $posts ) );
@@ -326,7 +351,9 @@ class Migrate_Command extends WP_CLI_Command {
 
 		// If there is no mapped PPA user then resolve that.
 		if ( ! empty( $ppa_user_id ) ) {
-			return intval( $ppa_user_id );
+			if ( is_scalar( $ppa_user_id ) ) {
+				return (int) $ppa_user_id;
+			}
 		}
 
 		/**
@@ -361,12 +388,144 @@ class Migrate_Command extends WP_CLI_Command {
 		// If this fails we want the debug data, so print out the
 		// arguments so we can reproduce later.
 		if ( is_wp_error( $ppa_user_id ) ) {
-			WP_CLI::error( 'Could not create Authorship user with these arguments:', false );
-			WP_CLI::error( $ppa_user_id, false );
-			exit( 1 );
+			WP_CLI::error(
+				sprintf(
+					'Could not create Authorship user with these arguments: %s',
+					$ppa_user_id->get_error_message()
+				)
+			);
 		}
 
 		return $ppa_user_id;
+	}
+
+	/**
+	 * Pause between migration batches.
+	 *
+	 * @param array<string,mixed> $assoc_args CLI assoc args.
+	 * @param string              $migration Migration subcommand identifier.
+	 * @param int                 $count Number of processed posts so far.
+	 * @param int                 $processed_in_batch Number of posts processed in current batch.
+	 */
+	private function pause_between_batches( array $assoc_args, string $migration, int $count, int $processed_in_batch ) : void {
+		if ( $processed_in_batch <= 0 ) {
+			return;
+		}
+
+		$pause_seconds = $this->get_batch_pause_seconds( $assoc_args, $migration );
+		/**
+		 * Fires when migration batch pause duration is resolved.
+		 *
+		 * @param float               $pause_seconds Resolved pause length in seconds.
+		 * @param string              $migration Migration subcommand identifier.
+		 * @param array<string,mixed> $assoc_args Original CLI assoc args.
+		 * @param int                 $count Number of processed posts at pause point.
+		 */
+		do_action(
+			'authorship_migrate_batch_pause_resolved',
+			$pause_seconds,
+			$migration,
+			$assoc_args,
+			$count
+		);
+
+		if ( $pause_seconds <= 0 ) {
+			WP_CLI::line( sprintf( 'Processed %d posts, continuing without pause.', $count ) );
+			return;
+		}
+
+		WP_CLI::line(
+			sprintf(
+				'Processed %1$d posts, pausing for %2$s second(s)...',
+				$count,
+				$pause_seconds
+			)
+		);
+
+		usleep( (int) round( $pause_seconds * 1000000 ) );
+	}
+
+	/**
+	 * Resolve pause seconds between migration batches.
+	 *
+	 * @param array<string,mixed> $assoc_args CLI assoc args.
+	 * @param string              $migration Migration subcommand identifier.
+	 *
+	 * @return float
+	 */
+	private function get_batch_pause_seconds( array $assoc_args, string $migration ) : float {
+		$pause_seconds = 2.0;
+		if ( isset( $assoc_args['batch-pause'] ) && is_numeric( $assoc_args['batch-pause'] ) ) {
+			$pause_seconds = floatval( $assoc_args['batch-pause'] );
+		}
+		$pause_seconds = max( 0.0, $pause_seconds );
+
+		/**
+		 * Filter the pause duration between migration batches.
+		 *
+		 * @param float               $pause_seconds Pause length in seconds.
+		 * @param string              $migration Migration subcommand identifier.
+		 * @param array<string,mixed> $assoc_args Original CLI assoc args.
+		 */
+		$pause_seconds = apply_filters(
+			'authorship_migrate_batch_pause_seconds',
+			$pause_seconds,
+			$migration,
+			$assoc_args
+		);
+
+		if ( ! is_numeric( $pause_seconds ) ) {
+			return 0.0;
+		}
+
+		return max( 0.0, floatval( $pause_seconds ) );
+	}
+
+	/**
+	 * Resolve and normalize target post types for wp-authors migration.
+	 *
+	 * @param array<string,mixed> $assoc_args CLI assoc args.
+	 *
+	 * @return array<int,string>
+	 */
+	private function get_migration_post_types( array $assoc_args ) : array {
+		$post_type_arg = $assoc_args['post-type'] ?? 'post';
+
+		if ( ! is_string( $post_type_arg ) ) {
+			return [ 'post' ];
+		}
+
+		$post_types = array_values(
+			array_filter(
+				array_unique(
+					array_map(
+						'strtolower',
+						array_map( 'trim', explode( ',', $post_type_arg ) )
+					)
+				)
+			)
+		);
+
+		if ( empty( $post_types ) ) {
+			return [ 'post' ];
+		}
+
+		if ( in_array( 'any', $post_types, true ) ) {
+			return [ 'any' ];
+		}
+
+		$registered_post_types = array_values(
+			array_filter(
+				$post_types,
+				'post_type_exists'
+			)
+		);
+
+		if ( empty( $registered_post_types ) ) {
+			return [ 'post' ];
+		}
+
+		return $registered_post_types;
 	}
 
 	/**
@@ -397,9 +556,7 @@ class Migrate_Command extends WP_CLI_Command {
 			$wp_object_cache->memcache_debug = [];
 		}
 
-		if ( isset( $wp_object_cache->cache ) ) {
 			$wp_object_cache->cache = [];
-		}
 
 		if ( method_exists( $wp_object_cache, '__remoteset' ) ) {
 			// important!

--- a/tests/phpunit/includes/testcase.php
+++ b/tests/phpunit/includes/testcase.php
@@ -16,6 +16,13 @@ use const Authorship\GUEST_ROLE;
  */
 abstract class TestCase extends \WP_UnitTestCase {
 	/**
+	 * Output buffer level captured in setUp().
+	 *
+	 * @var int
+	 */
+	private $output_buffer_level = 0;
+
+	/**
 	 * Users.
 	 *
 	 * @var \WP_User[]
@@ -50,7 +57,17 @@ abstract class TestCase extends \WP_UnitTestCase {
 
 	public function setUp() : void {
 		parent::setUp();
+		$this->output_buffer_level = ob_get_level();
+		ob_start();
 
 		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%/' );
+	}
+
+	public function tearDown() : void {
+		while ( ob_get_level() > $this->output_buffer_level ) {
+			ob_end_clean();
+		}
+
+		parent::tearDown();
 	}
 }

--- a/tests/phpunit/test-cli.php
+++ b/tests/phpunit/test-cli.php
@@ -14,11 +14,19 @@ use const Authorship\POSTS_PARAM;
 use const Authorship\TAXONOMY;
 
 class TestCLI extends TestCase {
+	/**
+	 * Captured pause-resolution events.
+	 *
+	 * @var array<int,array<string,mixed>>
+	 */
+	protected $pause_events = [];
+
 	public function set_up() {
 		parent::set_up();
 		require_once dirname( __DIR__, 2 ) . '/inc/cli/namespace.php';
 		require_once dirname( __DIR__, 2 ) . '/inc/cli/class-migrate-command.php';
 		CLI\bootstrap();
+		$this->pause_events = [];
 	}
 
 	public function testMigratePostTypePost() : void {
@@ -40,6 +48,7 @@ class TestCLI extends TestCase {
 		$command->wp_authors( [], [
 			'dry-run' => false,
 			'post-type' => 'post', // Note, have to set default values manually.
+			'batch-pause' => '0',
 		] );
 
 		// Check migration command has correctly set the author.
@@ -68,11 +77,489 @@ class TestCLI extends TestCase {
 		$command->wp_authors( [], [
 			'dry-run' => false,
 			'post-type' => 'post,page',
+			'batch-pause' => '0',
 		] );
 
 		// Check migration command has correctly set the author.
 		$authorship_authors = \Authorship\get_authors( $page1 );
 		$this->assertCount( 1, $authorship_authors );
 		$this->assertSame( self::$users['editor']->ID, $authorship_authors[0]->ID );
+	}
+
+	public function testMigratePostTypeDefaultsToPostWhenNotProvided() : void {
+		$factory = self::factory()->post;
+
+		$post = $factory->create_and_get( [
+			'post_author' => self::$users['editor']->ID,
+		] );
+
+		wp_set_post_terms( $post->ID, [], TAXONOMY );
+
+		$authorship_authors = \Authorship\get_authors( $post );
+		$this->assertCount( 0, $authorship_authors );
+
+		$command = new CLI\Migrate_Command();
+		$command->wp_authors( [], [
+			'dry-run' => false,
+			'batch-pause' => '0',
+		] );
+
+		$authorship_authors = \Authorship\get_authors( $post );
+		$this->assertCount( 1, $authorship_authors );
+		$this->assertSame( self::$users['editor']->ID, $authorship_authors[0]->ID );
+	}
+
+	public function testMigratePostTypeListIsTrimmedAndEmptyValuesIgnored() : void {
+		$factory = self::factory()->post;
+
+		$page = $factory->create_and_get( [
+			'post_author' => self::$users['editor']->ID,
+			'post_type' => 'page',
+		] );
+
+		wp_set_post_terms( $page->ID, [], TAXONOMY );
+
+		$authorship_authors = \Authorship\get_authors( $page );
+		$this->assertCount( 0, $authorship_authors );
+
+		$command = new CLI\Migrate_Command();
+		$command->wp_authors( [], [
+			'dry-run' => false,
+			'post-type' => ' post, page , , ',
+			'batch-pause' => '0',
+		] );
+
+		$authorship_authors = \Authorship\get_authors( $page );
+		$this->assertCount( 1, $authorship_authors );
+		$this->assertSame( self::$users['editor']->ID, $authorship_authors[0]->ID );
+	}
+
+	public function testMigratePostTypeFallsBackToPostWhenUnknownTypeProvided() : void {
+		$factory = self::factory()->post;
+
+		$post = $factory->create_and_get( [
+			'post_author' => self::$users['editor']->ID,
+		] );
+
+		wp_set_post_terms( $post->ID, [], TAXONOMY );
+
+		$authorship_authors = \Authorship\get_authors( $post );
+		$this->assertCount( 0, $authorship_authors );
+
+		$command = new CLI\Migrate_Command();
+		$command->wp_authors( [], [
+			'dry-run' => false,
+			'post-type' => 'not-a-real-post-type',
+			'batch-pause' => '0',
+		] );
+
+		$authorship_authors = \Authorship\get_authors( $post );
+		$this->assertCount( 1, $authorship_authors );
+		$this->assertSame( self::$users['editor']->ID, $authorship_authors[0]->ID );
+	}
+
+	public function testMigratePostTypeIncludesRegisteredCustomType() : void {
+		$factory = self::factory()->post;
+		$post_type = 'book';
+		$post_type_preexisting = post_type_exists( $post_type );
+
+		if ( ! $post_type_preexisting ) {
+			register_post_type(
+				$post_type,
+				[
+					'public' => true,
+					'supports' => [ 'author' ],
+				]
+			);
+			register_taxonomy_for_object_type( TAXONOMY, $post_type );
+		}
+
+		try {
+			$book = $factory->create_and_get( [
+				'post_author' => self::$users['editor']->ID,
+				'post_type' => $post_type,
+			] );
+
+			wp_set_post_terms( $book->ID, [], TAXONOMY );
+
+			$authorship_authors = \Authorship\get_authors( $book );
+			$this->assertCount( 0, $authorship_authors );
+
+			$command = new CLI\Migrate_Command();
+			$command->wp_authors( [], [
+				'dry-run' => false,
+				'post-type' => $post_type,
+				'batch-pause' => '0',
+			] );
+
+			$authorship_authors = \Authorship\get_authors( $book );
+			$this->assertCount( 1, $authorship_authors );
+			$this->assertSame( self::$users['editor']->ID, $authorship_authors[0]->ID );
+		} finally {
+			if ( ! $post_type_preexisting && post_type_exists( $post_type ) ) {
+				unregister_post_type( $post_type );
+			}
+		}
+	}
+
+	public function testMigratePostTypeAnyProcessesSupportedTypes() : void {
+		$factory = self::factory()->post;
+
+		$page = $factory->create_and_get( [
+			'post_author' => self::$users['editor']->ID,
+			'post_type' => 'page',
+		] );
+
+		wp_set_post_terms( $page->ID, [], TAXONOMY );
+
+		$authorship_authors = \Authorship\get_authors( $page );
+		$this->assertCount( 0, $authorship_authors );
+
+		$command = new CLI\Migrate_Command();
+		$command->wp_authors( [], [
+			'dry-run' => false,
+			'post-type' => 'any',
+			'batch-pause' => '0',
+		] );
+
+		$authorship_authors = \Authorship\get_authors( $page );
+		$this->assertCount( 1, $authorship_authors );
+		$this->assertSame( self::$users['editor']->ID, $authorship_authors[0]->ID );
+	}
+
+	public function testMigrateRespectsZeroBatchPause() : void {
+		$factory = self::factory()->post;
+
+		$post = $factory->create_and_get( [
+			'post_author' => self::$users['editor']->ID,
+		] );
+
+		wp_set_post_terms( $post->ID, [], TAXONOMY );
+
+		$command = new CLI\Migrate_Command();
+
+		$start_time = microtime( true );
+		$command->wp_authors( [], [
+			'dry-run' => true,
+			'post-type' => 'post',
+			'batch-pause' => '0',
+		] );
+		$elapsed = microtime( true ) - $start_time;
+
+		$this->assertLessThan(
+			1.5,
+			$elapsed,
+			'Expected wp authors migration to skip fixed delay when batch-pause is zero.'
+		);
+	}
+
+	public function testMigratePauseCanBeOverriddenByFilter() : void {
+		$factory = self::factory()->post;
+
+		$post = $factory->create_and_get( [
+			'post_author' => self::$users['editor']->ID,
+		] );
+
+		wp_set_post_terms( $post->ID, [], TAXONOMY );
+
+		$command = new CLI\Migrate_Command();
+
+		add_filter( 'authorship_migrate_batch_pause_seconds', [ $this, 'disableMigrationPause' ], 10, 3 );
+
+		try {
+			$start_time = microtime( true );
+			$command->wp_authors( [], [
+				'dry-run' => true,
+				'post-type' => 'post',
+			] );
+			$elapsed = microtime( true ) - $start_time;
+		} finally {
+			remove_filter( 'authorship_migrate_batch_pause_seconds', [ $this, 'disableMigrationPause' ], 10 );
+		}
+
+		$this->assertLessThan(
+			1.5,
+			$elapsed,
+			'Expected filter override to disable migration batch pause.'
+		);
+	}
+
+	public function testMigrateNegativeBatchPauseIsClampedToZero() : void {
+		$factory = self::factory()->post;
+
+		$post = $factory->create_and_get( [
+			'post_author' => self::$users['editor']->ID,
+		] );
+
+		wp_set_post_terms( $post->ID, [], TAXONOMY );
+
+		$command = new CLI\Migrate_Command();
+
+		$start_time = microtime( true );
+		$command->wp_authors( [], [
+			'dry-run' => true,
+			'post-type' => 'post',
+			'batch-pause' => '-5',
+		] );
+		$elapsed = microtime( true ) - $start_time;
+
+		$this->assertLessThan(
+			1.5,
+			$elapsed,
+			'Expected negative batch-pause values to be clamped to zero pause.'
+		);
+	}
+
+	/**
+	 * Disable migration pause for testing filter overrides.
+	 *
+	 * @param float               $pause_seconds Current pause value.
+	 * @param string              $migration Migration subcommand.
+	 * @param array<string,mixed> $assoc_args CLI assoc args.
+	 *
+	 * @return float
+	 */
+	public function disableMigrationPause( float $pause_seconds, string $migration, array $assoc_args ) : float {
+		$this->assertSame( 'wp-authors', $migration );
+		$this->assertArrayHasKey( 'post-type', $assoc_args );
+
+		return 0.0;
+	}
+
+	public function testMigratePauseResolutionActionFiresForWpAuthors() : void {
+		$factory = self::factory()->post;
+
+		$post = $factory->create_and_get( [
+			'post_author' => self::$users['editor']->ID,
+		] );
+
+		wp_set_post_terms( $post->ID, [], TAXONOMY );
+
+		$command = new CLI\Migrate_Command();
+
+		add_action( 'authorship_migrate_batch_pause_resolved', [ $this, 'capturePauseResolution' ], 10, 4 );
+
+		try {
+			$command->wp_authors( [], [
+				'dry-run' => true,
+				'post-type' => 'post',
+				'batch-pause' => '-5',
+			] );
+		} finally {
+			remove_action( 'authorship_migrate_batch_pause_resolved', [ $this, 'capturePauseResolution' ], 10 );
+		}
+
+		$this->assertNotEmpty( $this->pause_events );
+		$this->assertSame( 'wp-authors', $this->pause_events[0]['migration'] );
+		$this->assertSame( 0.0, $this->pause_events[0]['pause_seconds'] );
+		$this->assertSame( '-5', $this->pause_events[0]['assoc_args']['batch-pause'] );
+	}
+
+	public function testMigratePauseResolutionActionFiresForPpa() : void {
+		$factory = self::factory()->post;
+		$author_taxonomy_preexisting = taxonomy_exists( 'author' );
+		$term_id = 0;
+
+		if ( ! $author_taxonomy_preexisting ) {
+			register_taxonomy(
+				'author',
+				'post',
+				[
+					'public'    => false,
+					'query_var' => false,
+					'rewrite'   => false,
+				]
+			);
+		}
+
+		$post = $factory->create_and_get( [
+			'post_author' => self::$users['editor']->ID,
+		] );
+
+		$term = wp_insert_term( 'PPA Test Author', 'author', [
+			'slug' => 'ppa-test-author',
+		] );
+		$this->assertIsArray( $term );
+		$this->assertArrayHasKey( 'term_id', $term );
+
+		$term_id = (int) $term['term_id'];
+		wp_set_object_terms( $post->ID, [ $term_id ], 'author' );
+		update_term_meta( $term_id, 'user_id', self::$users['author']->ID );
+
+		$command = new CLI\Migrate_Command();
+
+		add_action( 'authorship_migrate_batch_pause_resolved', [ $this, 'capturePauseResolution' ], 10, 4 );
+
+		try {
+			$command->ppa( [], [
+				'dry-run' => true,
+				'overwrite-authors' => true,
+				'batch-pause' => '0',
+			] );
+		} finally {
+			remove_action( 'authorship_migrate_batch_pause_resolved', [ $this, 'capturePauseResolution' ], 10 );
+
+			if ( $term_id > 0 && taxonomy_exists( 'author' ) ) {
+				wp_delete_term( $term_id, 'author' );
+			}
+
+			if ( ! $author_taxonomy_preexisting && taxonomy_exists( 'author' ) ) {
+				unregister_taxonomy( 'author' );
+			}
+		}
+
+		$ppa_event = array_filter(
+			$this->pause_events,
+			function ( array $event ) : bool {
+				return $event['migration'] === 'ppa';
+			}
+		);
+
+		$this->assertNotEmpty( $ppa_event );
+		$event = array_values( $ppa_event )[0];
+		$this->assertSame( 0.0, $event['pause_seconds'] );
+		$this->assertSame( '0', $event['assoc_args']['batch-pause'] );
+	}
+
+	public function testMigratePauseResolutionActionFiresPerProcessedBatch() : void {
+		$factory = self::factory()->post;
+
+		$baseline_count = count(
+			get_posts( [
+				'fields' => 'ids',
+				'posts_per_page' => -1,
+				'post_type' => 'post',
+				'post_status' => 'any',
+				'ignore_sticky_posts' => true,
+				'suppress_filters' => false,
+				'tax_query' => [
+					[
+						'taxonomy' => TAXONOMY,
+						'operator' => 'NOT EXISTS',
+					],
+				],
+			] )
+		);
+
+		for ( $i = 0; $i < 101; $i++ ) {
+			$post = $factory->create_and_get( [
+				'post_author' => self::$users['editor']->ID,
+			] );
+			wp_set_post_terms( $post->ID, [], TAXONOMY );
+		}
+
+		$expected_total = $baseline_count + 101;
+		$expected_batches = (int) ceil( $expected_total / 100 );
+
+		$command = new CLI\Migrate_Command();
+
+		add_action( 'authorship_migrate_batch_pause_resolved', [ $this, 'capturePauseResolution' ], 10, 4 );
+
+		try {
+			$command->wp_authors( [], [
+				'dry-run' => true,
+				'post-type' => 'post',
+				'batch-pause' => '0',
+			] );
+		} finally {
+			remove_action( 'authorship_migrate_batch_pause_resolved', [ $this, 'capturePauseResolution' ], 10 );
+		}
+
+		$events = array_values(
+			array_filter(
+				$this->pause_events,
+				function ( array $event ) : bool {
+					return $event['migration'] === 'wp-authors';
+				}
+			)
+		);
+
+		$this->assertCount( $expected_batches, $events );
+		$this->assertSame( min( 100, $expected_total ), $events[0]['count'] );
+		$this->assertSame( $expected_total, $events[ $expected_batches - 1 ]['count'] );
+
+		foreach ( $events as $event ) {
+			$this->assertSame( 0.0, $event['pause_seconds'] );
+			$this->assertSame( '0', $event['assoc_args']['batch-pause'] );
+		}
+	}
+
+	public function testMigratePauseResolutionActionSkipsEmptyPpaBatches() : void {
+		$factory = self::factory()->post;
+		$author_taxonomy_preexisting = taxonomy_exists( 'author' );
+		$term_id = 0;
+
+		if ( ! $author_taxonomy_preexisting ) {
+			register_taxonomy(
+				'author',
+				'post',
+				[
+					'public'    => false,
+					'query_var' => false,
+					'rewrite'   => false,
+				]
+			);
+		}
+
+		$post = $factory->create_and_get( [
+			'post_author' => self::$users['editor']->ID,
+		] );
+
+		$term = wp_insert_term( 'PPA Skip Author', 'author', [
+			'slug' => 'ppa-skip-author',
+		] );
+		$this->assertIsArray( $term );
+		$this->assertArrayHasKey( 'term_id', $term );
+
+		$term_id = (int) $term['term_id'];
+		wp_set_object_terms( $post->ID, [ $term_id ], 'author' );
+		\Authorship\set_authors( $post, [ self::$users['editor']->ID ] );
+
+		$command = new CLI\Migrate_Command();
+
+		add_action( 'authorship_migrate_batch_pause_resolved', [ $this, 'capturePauseResolution' ], 10, 4 );
+
+		try {
+			$command->ppa( [], [
+				'dry-run' => true,
+				'batch-pause' => '0',
+			] );
+		} finally {
+			remove_action( 'authorship_migrate_batch_pause_resolved', [ $this, 'capturePauseResolution' ], 10 );
+
+			if ( $term_id > 0 && taxonomy_exists( 'author' ) ) {
+				wp_delete_term( $term_id, 'author' );
+			}
+
+			if ( ! $author_taxonomy_preexisting && taxonomy_exists( 'author' ) ) {
+				unregister_taxonomy( 'author' );
+			}
+		}
+
+		$ppa_events = array_filter(
+			$this->pause_events,
+			function ( array $event ) : bool {
+				return $event['migration'] === 'ppa';
+			}
+		);
+
+		$this->assertEmpty( $ppa_events );
+	}
+
+	/**
+	 * Capture pause-resolution action payloads.
+	 *
+	 * @param float               $pause_seconds Pause in seconds.
+	 * @param string              $migration Migration subcommand identifier.
+	 * @param array<string,mixed> $assoc_args CLI assoc args.
+	 * @param int                 $count Processed count at pause point.
+	 */
+	public function capturePauseResolution( float $pause_seconds, string $migration, array $assoc_args, int $count ) : void {
+		$this->pause_events[] = [
+			'pause_seconds' => $pause_seconds,
+			'migration' => $migration,
+			'assoc_args' => $assoc_args,
+			'count' => $count,
+		];
 	}
 }

--- a/tests/phpunit/test-multisite.php
+++ b/tests/phpunit/test-multisite.php
@@ -58,6 +58,7 @@ class TestMultisite extends TestCase {
 	public function testSuperAdminWithNoRoleOnSite() {
 		// Change site.
 		switch_to_blog( self::$sub_site->blog_id );
+		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%/' );
 
 		// Confirm no role on current site.
 		$super_admin = get_user_by( 'ID', self::$super_admin->ID );


### PR DESCRIPTION
## Summary
- add configurable migration pacing (`--batch-pause`) for CLI migration commands
- add pause filter/action extension points for integrators
- normalize/validate `--post-type` input for `wp-authors` migration
- stabilize CLI test fixture behavior and multisite setup
- document migration pacing controls in README

## Files
- `inc/cli/class-migrate-command.php`
- `tests/phpunit/test-cli.php`
- `tests/phpunit/test-multisite.php`
- `tests/phpunit/includes/testcase.php`
- `README.md`

## Verification
- `composer test:ut` (pass; upstream test suite currently emits deprecation/risky noise under PHP 8.5)

## Notes
- This PR is scoped to CLI migration behavior and associated tests/docs only.
