### PR TITLE
Editor: move AuthorsSelect init side effects to useEffect

### DIFF
--- a/src/components/AuthorsSelect.tsx
+++ b/src/components/AuthorsSelect.tsx
@@ -1,5 +1,5 @@
 import { get, isEqual } from 'lodash';
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement, useEffect, useRef, useState } from 'react';
 import { Styles } from 'react-select';
 import type {
 	WP_REST_API_Error,
@@ -53,30 +53,63 @@ const AuthorsSelect = ( props: AuthorsSelectProps ): ReactElement => {
 	const isDisabled = ! hasAssignAuthorAction;
 
 	const [ selected, setSelected ] = useState<Option[]>( [] );
+	const hasInitializedSelection = useRef<boolean>( false );
 
-	const preloadedAuthorIDs = preloadedAuthorOptions.authors.map( author => author.value );
+	useEffect( () => {
+		const preloadedAuthorIDs = preloadedAuthorOptions.authors.map( author => author.value );
 
-	if ( ! selected.length && isEqual( preloadedAuthorIDs, currentAuthorIDs ) ) {
-		setSelected( preloadedAuthorOptions.authors );
-	} else if ( currentAuthorIDs !== undefined && currentAuthorIDs.length && ! selected.length ) {
+		if ( hasInitializedSelection.current || selected.length ) {
+			return;
+		}
 
-		const path = addQueryArgs(
-			'/authorship/v1/users/',
-			{
-				include: currentAuthorIDs,
-				orderby: 'include',
-				post_type: postType,
-			}
-		);
+		if ( isEqual( preloadedAuthorIDs, currentAuthorIDs ) ) {
+			setSelected( preloadedAuthorOptions.authors );
+			hasInitializedSelection.current = true;
+			return;
+		}
 
-		const api: Promise<WP_REST_API_User[]> = apiFetch( { path } );
+		if ( currentAuthorIDs !== undefined && currentAuthorIDs.length ) {
+			hasInitializedSelection.current = true;
 
-		api.then( users => {
-			setSelected( users.map( createOption ) );
-		} ).catch( ( error: WP_REST_API_Error ) => {
-			onError( error.message );
-		} );
-	}
+			const path = addQueryArgs(
+				'/authorship/v1/users/',
+				{
+					include: currentAuthorIDs,
+					orderby: 'include',
+					post_type: postType,
+				}
+			);
+
+			let isCancelled = false;
+			const api: Promise<WP_REST_API_User[]> = apiFetch( { path } );
+
+			api.then( users => {
+				if ( isCancelled ) {
+					return;
+				}
+
+				setSelected( users.map( createOption ) );
+			} ).catch( ( error: WP_REST_API_Error ) => {
+				if ( isCancelled ) {
+					return;
+				}
+
+				onError( error.message );
+			} );
+
+			return () => {
+				isCancelled = true;
+			};
+		}
+
+		hasInitializedSelection.current = true;
+	}, [
+		currentAuthorIDs,
+		onError,
+		postType,
+		preloadedAuthorOptions.authors,
+		selected.length,
+	] );
 
 	/**
 	 * Asynchronously loads the options for the control based on the search parameter.

--- a/src/components/AuthorsSelect.tsx
+++ b/src/components/AuthorsSelect.tsx
@@ -101,8 +101,6 @@ const AuthorsSelect = ( props: AuthorsSelectProps ): ReactElement => {
 				isCancelled = true;
 			};
 		}
-
-		hasInitializedSelection.current = true;
 	}, [
 		currentAuthorIDs,
 		onError,


### PR DESCRIPTION
## What this does

Moves initial author-selection setup out of render and into `useEffect`.

## What this fixes

Prevents render-time state updates and render-time async fetch work in `AuthorsSelect`, which can lead to repeated initialization and unstable editor behavior.

## What this changes

- moves initial selected-author hydration into `useEffect`
- adds a one-time initialization guard
- moves async preload fetch into the effect lifecycle
- adds a cancellation guard so stale async completion does not update state

## Why

The current component mutates state and starts async work while rendering. React components should keep render pure and perform this setup in effects.

## Scope

This PR is intentionally narrow with only front-end concerns.

Included:
- `src/components/AuthorsSelect.tsx`

Not included:
- broader frontend modernization
- react-select upgrade work
- hook migration
- accessibility/UI follow-up changes
