### PR TITLE
Query: make author query reset callback self-cleaning

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -665,26 +665,38 @@ function action_pre_get_posts( WP_Query $query ) : void {
 	 * @param WP_Post[]|null $posts Array of post objects. Passed by reference.
 	 * @param WP_Query       $query The WP_Query instance.
 	 */
-	add_filter( 'posts_pre_query', function( ?array $posts, WP_Query $query ) use ( &$stored_values, $user_ids ) : ?array {
+	$restore_query_vars = static function( ?array $posts, WP_Query $filtered_query ) use ( &$restore_query_vars, &$stored_values, $user_ids, $query ) : ?array {
+		if ( $filtered_query !== $query ) {
+			return $posts;
+		}
+
+		remove_filter( 'posts_pre_query', $restore_query_vars, 999 );
+
 		if ( empty( $stored_values ) ) {
 			return $posts;
 		}
 
 		// Reset the query vars to their original values.
 		foreach ( $stored_values as $concern => $value ) {
-			$query->set( $concern, $value );
+			$filtered_query->set( $concern, $value );
 		}
 
 		// Specifically set `author` when `author_name` is in use as WP_Query also sets `author` internally.
-		if ( ! empty( $stored_values['author_name'] ) ) {
-			$query->set( 'author', $user_ids[0] );
+		if (
+			array_key_exists( 'author_name', $stored_values )
+			&& is_string( $stored_values['author_name'] )
+			&& '' !== $stored_values['author_name']
+		) {
+			$filtered_query->set( 'author', $user_ids[0] );
 		}
 
 		// Clear the recorded values so subsequent queries are not affected.
 		$stored_values = [];
 
 		return $posts;
-	}, 999, 2 );
+	};
+
+	add_filter( 'posts_pre_query', $restore_query_vars, 999, 2 );
 }
 
 /**

--- a/tests/phpunit/test-wp-query.php
+++ b/tests/phpunit/test-wp-query.php
@@ -336,4 +336,51 @@ class TestWPQuery extends TestCase {
 			$query2->get( 'author' )
 		);
 	}
+
+	public function testAuthorFilteredQueriesDoNotAccumulatePostsPreQueryCallbacks() : void {
+		$factory = self::factory()->post;
+
+		$factory->create_and_get( [
+			POSTS_PARAM => [
+				self::$users['editor']->ID,
+			],
+		] );
+
+		$before = $this->countHookCallbacks( 'posts_pre_query' );
+
+		for ( $i = 0; $i < 3; $i++ ) {
+			$query = new WP_Query();
+			$query->query( [
+				'post_type' => 'post',
+				'author'    => self::$users['editor']->ID,
+				'fields'    => 'ids',
+			] );
+		}
+
+		$after = $this->countHookCallbacks( 'posts_pre_query' );
+
+		$this->assertSame( $before, $after );
+	}
+
+	/**
+	 * Count total callbacks registered for a hook across all priorities.
+	 *
+	 * @param string $hook Hook name.
+	 * @return int
+	 */
+	private function countHookCallbacks( string $hook ) : int {
+		global $wp_filter;
+
+		if ( ! isset( $wp_filter[ $hook ] ) || ! $wp_filter[ $hook ] instanceof \WP_Hook ) {
+			return 0;
+		}
+
+		$count = 0;
+
+		foreach ( $wp_filter[ $hook ]->callbacks as $callbacks ) {
+			$count += count( $callbacks );
+		}
+
+		return $count;
+	}
 }


### PR DESCRIPTION
Authorship temporarily hooks into WordPress query processing when someone loads author-filtered content. Temporary query hooks should clean themselves up once they have done their work. In this case, the temporary hook was not removed after use over repeated queries. As a result, extra copies of that hook could pile up in memory during the request. 

This is a stability and correctness fix to make the temporary hook clean itself up immediately after it handles the query it was created for. This patch keeps the existing author-query rewrite behavior intact, but fixes the callback lifecycle so repeated author-filtered queries do not leave behind extra `posts_pre_query` callbacks that can leak into later requests.

## Summary

Make the temporary `posts_pre_query` callback used by author-query rewriting remove itself after it has handled the intended query.

## What changed

- scope the restore callback to the specific `WP_Query` instance that registered it
- remove the callback before restoring query vars
- keep the original query-var restoration behavior intact
- add a regression test that confirms repeated author-filtered queries do not
  accumulate `posts_pre_query` callbacks

## Why

The current implementation clears stored values after the query runs, but the temporary callback itself remains registered. Repeated author-filtered queries can therefore leave behind extra callbacks on `posts_pre_query`.

This patch keeps the callback lifecycle aligned with the query it was created for and prevents callback accumulation across later queries.

## Scope

This PR is intentionally narrow and limited to query callback lifecycle cleanup.

Included:
- `inc/namespace.php`
- `tests/phpunit/test-wp-query.php`

Not included:
- broader author-query behavior changes
- post-type semantics changes
- multisite or deletion behavior work

## Verification

- `vendor/bin/phpunit --filter TestWPQuery`
- `php -l inc/namespace.php`
- `php -l tests/phpunit/test-wp-query.php`
