### PR TITLE
REST: harden guest author username collision handling

### DIFF
--- a/inc/class-users-controller.php
+++ b/inc/class-users-controller.php
@@ -29,6 +29,8 @@ class Users_Controller extends WP_REST_Users_Controller {
 
 	const _NAMESPACE = 'authorship/v1';
 	const BASE = 'users';
+	const DEFAULT_GUEST_USERNAME = 'guestauthor';
+	const MAX_USERNAME_LENGTH = 60;
 
 	/**
 	 * Constructor.
@@ -191,8 +193,10 @@ class Users_Controller extends WP_REST_Users_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function create_item( $request ) {
-		$username = sanitize_title( sanitize_user( $request->get_param( 'name' ), true ) );
-		$username = preg_replace( '/[^a-z0-9]/', '', $username );
+		$name_param = $request->get_param( 'name' );
+		$name       = is_string( $name_param ) ? $name_param : '';
+		$username   = $this->normalize_guest_username( $name );
+		$username   = $this->get_unique_guest_username( $username );
 
 		$request->set_param( 'username', $username );
 
@@ -208,15 +212,65 @@ class Users_Controller extends WP_REST_Users_Controller {
 		 *     @type WP_Error $errors        WP_Error object containing any errors found.
 		 * }
 		 */
-		add_filter( 'wpmu_validate_user_signup', function( array $result ) : array {
-			/** @var WP_Error $errors */
-			$errors = $result['errors'];
-			$errors->remove( 'user_email' );
+		add_filter( 'wpmu_validate_user_signup', [ $this, 'filter_guest_author_signup_validation' ] );
 
-			return $result;
-		} );
+		try {
+			return parent::create_item( $request );
+		} finally {
+			remove_filter( 'wpmu_validate_user_signup', [ $this, 'filter_guest_author_signup_validation' ] );
+		}
+	}
 
-		return parent::create_item( $request );
+	/**
+	 * Filters validated signup data for guest author creation.
+	 *
+	 * @param mixed[] $result Signup validation result.
+	 * @return mixed[] Signup validation result.
+	 */
+	public function filter_guest_author_signup_validation( array $result ) : array {
+		if ( isset( $result['errors'] ) && $result['errors'] instanceof WP_Error ) {
+			$result['errors']->remove( 'user_email' );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Normalizes a guest author username from the provided name.
+	 *
+	 * @param string $name Guest author display name.
+	 * @return string Normalized username candidate.
+	 */
+	protected function normalize_guest_username( string $name ) : string {
+		$username = sanitize_title( sanitize_user( $name, true ) );
+		$username = preg_replace( '/[^a-z0-9]/', '', $username );
+
+		if ( ! is_string( $username ) || '' === $username ) {
+			$username = self::DEFAULT_GUEST_USERNAME;
+		}
+
+		return substr( $username, 0, self::MAX_USERNAME_LENGTH );
+	}
+
+	/**
+	 * Ensures the guest author username is unique.
+	 *
+	 * @param string $username Username candidate.
+	 * @return string Unique username.
+	 */
+	protected function get_unique_guest_username( string $username ) : string {
+		$candidate = $username;
+		$suffix    = 2;
+
+		while ( username_exists( $candidate ) ) {
+			$suffix_string   = (string) $suffix;
+			$max_base_length = max( 1, self::MAX_USERNAME_LENGTH - strlen( $suffix_string ) - 1 );
+			$base            = substr( $username, 0, $max_base_length );
+			$candidate       = "{$base}-{$suffix_string}";
+			++$suffix;
+		}
+
+		return $candidate;
 	}
 
 	/**

--- a/tests/phpunit/test-rest-api-user-endpoint.php
+++ b/tests/phpunit/test-rest-api-user-endpoint.php
@@ -41,6 +41,53 @@ class TestRESTAPIUserEndpoint extends RESTAPITestCase {
 		$this->assertSame( [ GUEST_ROLE ], $data['roles'] );
 	}
 
+	public function testGuestAuthorDuplicateNameGetsUniqueUsername() : void {
+		wp_set_current_user( self::$users['editor']->ID );
+
+		$request = new WP_REST_Request( 'POST', self::$route );
+		$request->set_param( 'name', 'Duplicate Name' );
+
+		$first_response = self::rest_do_request( $request );
+		$first_data     = $first_response->get_data();
+		$first_message  = self::get_message( $first_response );
+
+		$this->assertSame( WP_Http::CREATED, $first_response->get_status(), $first_message );
+
+		$request = new WP_REST_Request( 'POST', self::$route );
+		$request->set_param( 'name', 'Duplicate Name' );
+
+		$second_response = self::rest_do_request( $request );
+		$second_data     = $second_response->get_data();
+		$second_message  = self::get_message( $second_response );
+
+		$this->assertSame( WP_Http::CREATED, $second_response->get_status(), $second_message );
+
+		$first_user  = get_userdata( (int) $first_data['id'] );
+		$second_user = get_userdata( (int) $second_data['id'] );
+
+		$this->assertNotFalse( $first_user );
+		$this->assertNotFalse( $second_user );
+		$this->assertSame( 'duplicatename', $first_user->user_login );
+		$this->assertMatchesRegularExpression( '/^duplicatename-[0-9]+$/', $second_user->user_login );
+	}
+
+	public function testGuestAuthorNonAsciiNameGetsFallbackUsername() : void {
+		wp_set_current_user( self::$users['editor']->ID );
+
+		$request = new WP_REST_Request( 'POST', self::$route );
+		$request->set_param( 'name', '李小龍' );
+
+		$response = self::rest_do_request( $request );
+		$data     = $response->get_data();
+		$message  = self::get_message( $response );
+
+		$this->assertSame( WP_Http::CREATED, $response->get_status(), $message );
+
+		$user = get_userdata( (int) $data['id'] );
+		$this->assertNotFalse( $user );
+		$this->assertMatchesRegularExpression( '/^guestauthor(?:-[0-9]+)?$/', $user->user_login );
+	}
+
 	/**
 	 * @dataProvider dataDisallowedFields
 	 *


### PR DESCRIPTION
Guest author creation should not fail just because two people share the same normalized name or because a display name (e.g., with non-ASCII characters) normalizes to an empty username. This patch keeps the existing endpoint contract intact while making username generation deterministic, resilient, and easier to reason about in real-world editorial workflows.

## Summary

Harden guest author creation so generated usernames remain valid and unique when names collide or normalize to an empty value.

## What changed

- normalize guest-author usernames from the provided display name
- fall back to `guestauthor` when normalization produces an empty username
- ensure generated usernames are unique before creating them
- remove the temporary signup-validation filter after the request completes
- add focused tests for duplicate-name and non-ASCII-name creation

## Why

The current guest-author create path assumes the first generated username is
usable. In practice, valid guest-author requests can collide with an existing
username or normalize to an empty string.

This change makes guest-author creation deterministic and more resilient without changing the endpoint contract.

## Scope

This PR is intentionally narrow and limited to guest-author username generation.

Included:
- `inc/class-users-controller.php`
- `tests/phpunit/test-rest-api-user-endpoint.php`

Not included:
- broader REST changes
- observability additions
- unrelated post insert or CLI behavior

## Verification

- `vendor/bin/phpunit --filter TestRESTAPIUserEndpoint`
- `php -l inc/class-users-controller.php`
- `php -l tests/phpunit/test-rest-api-user-endpoint.php`
