### PR TITLE
The v0.3.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Authorship
 
-Stable tag: 0.3.0  
+Stable tag: 0.3.1  
 Requires at least: 5.4  
 Tested up to: 6.9  
 Requires PHP: 8.2  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@humanmade/authorship",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humanmade/authorship",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Authorship",
   "private": true,
   "main": "src/index.tsx",

--- a/plugin.php
+++ b/plugin.php
@@ -9,7 +9,7 @@
  *
  * Plugin Name:  Authorship
  * Description:  Authorship plugin for WordPress.
- * Version:      0.3.0
+ * Version:      0.3.1
  * Plugin URI:   https://github.com/humanmade/authorship
  * Author:       Human Made, initially funded by Siemens.
  * Author URI:   https://humanmade.com/


### PR DESCRIPTION
Resolves PHP warning in error log when HMR runtime asset.php file is not present on disk.

- #184 